### PR TITLE
[add,fix] is_builtin()追加、makefile更新

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@ CFLAGS = -Wall -Wextra -Werror
 NAME = minishell
 
 SRCFILE =	srcs/utils/create_new_tcommand.c \
-			srcs/utils/free_commandslist.c
+			srcs/utils/free_commandslist.c \
+			srcs/utils/is_builtin.c
 
 TESTFILE =	tests/utils/test_create_new_tcommand.c \
-			tests/utils/test_free_commandslist.c
+			tests/utils/test_free_commandslist.c \
+			tests/utils/test_is_builtin.c
 
 OBJDIR = ./obj
 OBJECTS = $(addprefix $(OBJDIR)/, $(notdir $(SRCFILE:.c=.o)))
@@ -13,22 +15,22 @@ OBJECTS = $(addprefix $(OBJDIR)/, $(notdir $(SRCFILE:.c=.o)))
 TESTCORE = srcs/utils/create_new_tcommand.c \
 			tests/print_tcommand.c
 
-TEST = $(notdir $(basename $(TESTFILE)))
+TEST = $(notdir $(basename $(SRCFILE)))
 
 all: $(NAME)
 
 libft:
 	$(MAKE) bonus -C ./libft
 
-$(NAME): libft $(OBJECTS)
-	gcc -g $(SRCFILE) -I./includes -I./libft -L./libft -lft -o cub3D
+# $(NAME): libft $(OBJECTS)
+	# gcc -g $(SRCFILE) -I./includes -I./libft -L./libft -lft -o cub3D
 
 %.o: %.c
 	gcc $(CFLAGS) -c $< -o $@ -I./includes
 
 $(TEST): libft
-	gcc -g $(wildcard tests/*/$(addsuffix .c,$@)) \
-	$(wildcard srcs/*/$(addsuffix .c,$(subst test_,,$@))) \
+	gcc -g $(wildcard tests/*/$(addprefix test_,$(addsuffix .c,$@))) \
+	$(wildcard srcs/*/$(addsuffix .c,$@)) \
 	$(TESTCORE) -I./includes -I. -L./libft -lft -o test
 
 clean:

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -36,6 +36,7 @@ typedef struct	s_command {
 //utils
 t_command	*create_new_tcommand(void);
 void		free_commandslist(t_command **cmds);
+int			is_builtin(t_command *cmds);
 
 //for debug
 void		print_tcommand(t_command cmd);

--- a/srcs/utils/is_builtin.c
+++ b/srcs/utils/is_builtin.c
@@ -1,0 +1,27 @@
+#include <minishell.h>
+
+/*
+** t_command内、argv[0]を各ビルトインコマンドと比較、該当する場合、indexを返す。ない場合は、-1を返す。
+*/
+
+int		is_builtin(t_command *cmds)
+{
+	int			i;
+	const char	builtin_list[][7] = {
+		{"echo"},
+		{"cd"},
+		{"pwd"},
+		{"export"},
+		{"unset"},
+		{"env"},
+		{"exit"}};
+
+	i = 0;
+	while (i < 7)
+	{
+		if (!ft_strncmp(cmds->argv[0], builtin_list[i], 7))
+			return (i);
+		i++;
+	}
+	return (-1);
+}

--- a/tests/utils/test_is_builtin.c
+++ b/tests/utils/test_is_builtin.c
@@ -1,0 +1,28 @@
+#include "minishell.h"
+
+int		main(void)
+{
+	t_command test;
+
+	test.argv = malloc(sizeof(char**) * 2);
+	test.argv[1] = NULL;
+	test.argv[0] = ft_strdup("echo");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("cd");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("pwd");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("export");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("unset");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("env");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("exit");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("invalid");
+	printf("%d\n", is_builtin(&test));
+	test.argv[0] = ft_strdup("exportaaa");
+	printf("%d\n", is_builtin(&test));
+	return (0);
+}


### PR DESCRIPTION
built-in判定用の関数追加しました。
あわせてmakefileのテストを変更し、make 実装関数名でテストできるようにしました。