### PR TITLE
[add]create_newenv()追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,15 @@ CFLAGS = -Wall -Wextra -Werror
 NAME = minishell
 
 SRCFILE =	srcs/utils/create_new_tcommand.c \
-			srcs/utils/free_commandslist.c
+			srcs/utils/free_commandslist.c \
+			srcs/utils/is_builtin.c \
+			srcs/utils/create_newenv.c
 
 TESTFILE =	tests/utils/test_create_new_tcommand.c \
-			tests/utils/test_free_commandslist.c
+			tests/utils/test_free_commandslist.c \
+			tests/utils/test_is_builtin.c \
+			tests/utils/test_create_newenv.c
+
 
 OBJDIR = ./obj
 OBJECTS = $(addprefix $(OBJDIR)/, $(notdir $(SRCFILE:.c=.o)))
@@ -13,22 +18,22 @@ OBJECTS = $(addprefix $(OBJDIR)/, $(notdir $(SRCFILE:.c=.o)))
 TESTCORE = srcs/utils/create_new_tcommand.c \
 			tests/print_tcommand.c
 
-TEST = $(notdir $(basename $(TESTFILE)))
+TEST = $(notdir $(basename $(SRCFILE)))
 
 all: $(NAME)
 
 libft:
 	$(MAKE) bonus -C ./libft
 
-$(NAME): libft $(OBJECTS)
-	gcc -g $(SRCFILE) -I./includes -I./libft -L./libft -lft -o cub3D
+# $(NAME): libft $(OBJECTS)
+	# gcc -g $(SRCFILE) -I./includes -I./libft -L./libft -lft -o cub3D
 
 %.o: %.c
 	gcc $(CFLAGS) -c $< -o $@ -I./includes
 
 $(TEST): libft
-	gcc -g $(wildcard tests/*/$(addsuffix .c,$@)) \
-	$(wildcard srcs/*/$(addsuffix .c,$(subst test_,,$@))) \
+	gcc -g $(wildcard tests/*/$(addprefix test_,$(addsuffix .c,$@))) \
+	$(wildcard srcs/*/$(addsuffix .c,$@)) \
 	$(TESTCORE) -I./includes -I. -L./libft -lft -o test
 
 clean:

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -36,6 +36,8 @@ typedef struct	s_command {
 //utils
 t_command	*create_new_tcommand(void);
 void		free_commandslist(t_command **cmds);
+int			is_builtin(t_command *cmds);
+bool		create_newenv(void);
 
 //for debug
 void		print_tcommand(t_command cmd);

--- a/srcs/utils/create_newenv.c
+++ b/srcs/utils/create_newenv.c
@@ -1,0 +1,23 @@
+#include "minishell.h"
+
+/*
+** environをコピーした新しいenvを作成する。成功したらtrue、失敗したらfalseを返す。
+*/
+
+bool	create_newenv(void)
+{
+	extern char	**environ;
+	char		**new_env;
+	int			i;
+	size_t		size;
+
+	i = 0;
+	while (environ[i] != NULL)
+		i++;
+	size = (i + 1) * sizeof(char *);
+	if (!(new_env = (char **)malloc(size)))
+		return (false);
+	ft_memcpy(new_env, environ, size);
+	environ = new_env;
+	return (true);
+}

--- a/tests/utils/test_create_newenv.c
+++ b/tests/utils/test_create_newenv.c
@@ -1,0 +1,21 @@
+#include "minishell.h"
+
+int main(void)
+{
+	extern char	**environ;
+	int			i;
+	bool		ret;
+
+	//free(environ);
+	//stack領域のenvironはfreeできない。
+	ret = create_newenv();
+	i = 0;
+	while (environ[i] != NULL)
+	{
+		printf("%s\n", environ[i]);
+		i++;
+	}
+	free(environ);
+	//新しいenvironはheap領域にあるためfreeできる。
+	return (0);
+}


### PR DESCRIPTION
environをheap領域にコピーする関数です。
ヘッダーファイル、makefileのコンフリクトが起きそうな部分をあらかじめ取り込んでいます。