### PR TITLE
[fix] create_newenv修正

### DIFF
--- a/srcs/utils/create_newenv.c
+++ b/srcs/utils/create_newenv.c
@@ -2,6 +2,7 @@
 
 /*
 ** environをコピーした新しいenvを作成する。成功したらtrue、失敗したらfalseを返す。
+** environが持つ各文字列もheap領域にコピーする。
 */
 
 bool	create_newenv(void)
@@ -17,7 +18,13 @@ bool	create_newenv(void)
 	size = (i + 1) * sizeof(char *);
 	if (!(new_env = (char **)malloc(size)))
 		return (false);
-	ft_memcpy(new_env, environ, size);
+	new_env[i] = NULL;
+	i = 0;
+	while (environ[i] != NULL)
+	{
+		new_env[i] = ft_strdup(environ[i]);
+		i++;
+	}
 	environ = new_env;
 	return (true);
 }

--- a/tests/utils/test_create_newenv.c
+++ b/tests/utils/test_create_newenv.c
@@ -1,5 +1,22 @@
 #include "minishell.h"
 
+static void printenv()
+{
+	extern char **environ;
+	int i;
+
+	i = 0;
+	while (environ[i] != NULL)
+		i++;
+	i -= 5;
+	while (environ[i] != NULL)
+	{
+		printf("%s\n", environ[i]);
+		i++;
+	}
+	return ;
+}
+
 int main(void)
 {
 	extern char	**environ;
@@ -9,13 +26,9 @@ int main(void)
 	//free(environ);
 	//stack領域のenvironはfreeできない。
 	ret = create_newenv();
-	i = 0;
-	while (environ[i] != NULL)
-	{
-		printf("%s\n", environ[i]);
-		i++;
-	}
-	free(environ);
+	printenv();
+	ft_free_split(environ);
+	//free(environ);
 	//新しいenvironはheap領域にあるためfreeできる。
 	return (0);
 }


### PR DESCRIPTION
environの各文字列もheapにコピーするように変更しました。値の修正、メモリ開放を一貫した操作で行えるようになります。