### PR TITLE
[fix] 不要関数削除、libft修正、makefile修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,26 +17,28 @@ TESTFILE =	tests/utils/test_create_new_tcommand.c \
 OBJDIR = ./obj
 OBJECTS = $(addprefix $(OBJDIR)/, $(notdir $(SRCFILE:.c=.o)))
 
-TESTCORE = srcs/utils/create_new_tcommand.c \
+TESTCORE =	srcs/utils/create_new_tcommand.c \
+			srcs/utils/create_newenv.c \
 			tests/print_tcommand.c
+
 
 TEST = $(notdir $(basename $(SRCFILE)))
 
 all: $(NAME)
 
-libft:
-	$(MAKE) bonus -C ./libft
-
 # $(NAME): libft $(OBJECTS)
 	# gcc -g $(SRCFILE) -I./includes -I./libft -L./libft -lft -o cub3D
+
+libft:
+	$(MAKE) bonus -C ./libft
 
 %.o: %.c
 	gcc $(CFLAGS) -c $< -o $@ -I./includes
 
 $(TEST): libft
-	gcc -g $(wildcard tests/*/$(addprefix test_,$(addsuffix .c,$@))) \
+	gcc -g $(sort $(wildcard tests/*/$(addprefix test_,$(addsuffix .c,$@))) \
 	$(wildcard srcs/*/$(addsuffix .c,$@)) \
-	$(TESTCORE) -I./includes -I. -L./libft -lft -o test
+	$(TESTCORE)) -I./includes -I. -L./libft -lft -o test
 
 clean:
 	$(MAKE) clean -C ./libft

--- a/srcs/utils/add_newval_to_env.c
+++ b/srcs/utils/add_newval_to_env.c
@@ -1,18 +1,5 @@
 #include "minishell.h"
 
-static void	*ft_realloc(void *ptr, size_t size)
-{
-	void	*new;
-
-	if (!(new = malloc(size)))
-		return (NULL);
-	if (ptr == NULL)
-		return (new);
-	ft_memcpy(new, ptr, size);
-	free(ptr);
-	return (new);
-}
-
 /*
 ** environに新しいメンバを追加。追加する文字列は関数内でmallocする。
 ** mallocに失敗したときfalseを返す。

--- a/tests/utils/test_add_newval_to_env.c
+++ b/tests/utils/test_add_newval_to_env.c
@@ -1,23 +1,5 @@
 #include "minishell.h"
 
-static bool	create_newenv(void)
-{
-	extern char	**environ;
-	char		**new_env;
-	int			i;
-	size_t		size;
-
-	i = 0;
-	while (environ[i] != NULL)
-		i++;
-	size = (i + 1) * sizeof(char *);
-	if (!(new_env = (char **)malloc(size)))
-		return (false);
-	ft_memcpy(new_env, environ, size);
-	environ = new_env;
-	return (true);
-}
-
 //末尾5メンバのみ出力
 static void	print_env()
 {


### PR DESCRIPTION
テスト用に追加していたmerge済みのstatic関数を削除、libftのmakefile、libft.hにft_reallocを追加。makefileのテスト用コマンドからソースの重複を削除するように変更しました。現在のすべてのテストで動作確認済みです。