### PR TITLE
[fix] fix_addnewvaltoenv()

### DIFF
--- a/srcs/utils/add_newval_to_env.c
+++ b/srcs/utils/add_newval_to_env.c
@@ -17,7 +17,7 @@ bool	add_newval_to_env(const char *str)
 	i = 0;
 	while (environ[i] != NULL)
 		i++;
-	new_env = (char **)ft_realloc(environ, (i + 2) * sizeof(char *));
+	new_env = (char **)ft_sprealloc(environ, (i + 2) * sizeof(char *));
 	if (new_env == NULL)
 		return (false);
 	environ = new_env;

--- a/tests/utils/test_add_newval_to_env.c
+++ b/tests/utils/test_add_newval_to_env.c
@@ -28,6 +28,6 @@ int			main(void)
 	add_newval_to_env("test is success!");
 	add_newval_to_env("second test is success!");
 	print_env();
-
+	ft_free_split(environ);
 	return (0);
 }


### PR DESCRIPTION
ft_spreallocの使用へ修正しました。
テストでメモリーリークがないことを確認しています。