### PR TITLE
[add] execute_builtin()追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ SRCFILE =	srcs/main/main.c \
 			srcs/execute/do_redirection.c \
 			srcs/execute/get_cmd_frompath.c \
 			srcs/execute/execute_sequential.c \
-			srcs/execute/read_command.c
+			srcs/execute/read_command.c \
+			srcs/builtin/execute_unset.c
 
 
 
@@ -32,7 +33,8 @@ TESTFILE =	tests/utils/test_create_new_tcommand.c \
 			test/execute/test_do_redirection.c \
 			test/execute/test_get_cmd_frompath.c \
 			tests/execute/test_execute_sequential.c \
-			tests/execute/test_read_command.c
+			tests/execute/test_read_command.c \
+			tests/builtin/test_execute_unset.c
 
 
 SRCDIRS = $(dir $(SRCFILE))

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -51,6 +51,9 @@ void		redirect_output(t_command *cmds);
 char		*get_cmd_frompath(t_command *cmd);
 void		execute_sequential(t_command *cmd);
 
+//builtin
+void		execute_unset(t_command *cmd);
+
 //for debug
 void		print_tcommand(t_command cmd);
 

--- a/srcs/builtin/execute_unset.c
+++ b/srcs/builtin/execute_unset.c
@@ -1,0 +1,90 @@
+#include "minishell.h"
+
+/*
+** unset関数、引数に与えらえれた文字列に該当するkeyの環境変数を削除する。
+** 引数なし、keyに該当がないときは何もしない。終了ステータスはゼロ
+** 複数引数がある場合、該当するkeyをすべて削除。
+** return後、execute_builtin関数で、コマンド終了時の処理を呼び出す想定で実装します。
+*/
+
+static int	get_target_index(char *key)
+{
+	int			i;
+	int			len;
+	extern char	**environ;
+
+	i = 0;
+	while (environ[i] != NULL)
+	{
+		len = ft_strlen(key);
+		if (!ft_strncmp(key, environ[i], len) && environ[i][len] == '=')
+			break ;
+		i++;
+	}
+	return (i);
+}
+
+static void	copy_environ(char **new_env, int target_i, int len)
+{
+	extern char	**environ;
+	char		**env_p;
+	int			i;
+
+	env_p = environ;
+	i = 0;
+	while (i < len - 1)
+	{
+		if (i == target_i)
+		{
+			env_p++;
+			free(environ[i]);
+			target_i = -1;
+			continue ;
+		}
+		new_env[i] = *env_p;
+		i++;
+		env_p++;
+	}
+	new_env[len - 1] = NULL;
+	free(environ);
+	environ = new_env;
+	return ;
+}
+
+static bool	delete_key(char *key)
+{
+	extern char	**environ;
+	int			target_i;
+	int			len;
+	char		**new_env;
+
+	len = 0;
+	while (environ[len] != NULL)
+		len++;
+	new_env = (char **)malloc(len * sizeof(char *));
+	if (new_env == NULL)
+		return (false);
+	target_i = get_target_index(key);
+	copy_environ(new_env, target_i, len);
+	return (true);
+}
+
+void		execute_unset(t_command *cmd)
+{
+	int		i;
+	char	*env;
+	bool	ret;
+
+	i = 1;
+	while (cmd->argv[i] != NULL)
+	{
+		env = getenv(cmd->argv[i]);
+		if (env == NULL)
+			continue ;
+		ret = delete_key(cmd->argv[i]);
+		if (ret == false)
+			;//error
+		i++;
+	}
+	return ;
+}

--- a/tests/builtin/test_execute_unset.c
+++ b/tests/builtin/test_execute_unset.c
@@ -1,0 +1,37 @@
+#include "minishell.h"
+
+static void print_env()
+{
+	int			i;
+	extern char	**environ;
+	i = 0;
+	while (environ[i])
+		i++;
+	printf("current env num is %d.\n", i);
+	i = 0;
+	while(i < 10)
+	{
+		puts(environ[i]);
+		i++;
+	}
+	return ;
+}
+
+int main(void)
+{
+	int			i;
+	t_command	*cmd;
+	extern char	**environ;
+
+	create_newenv();
+	print_env();
+	puts("-------------");
+	cmd = create_new_tcommand();
+	cmd->argv = ft_split("unset,HOME,USER",',');
+	execute_unset(cmd);
+	print_env();
+	ft_free_split(environ);
+	ft_free_split(cmd->argv);
+	free(cmd);
+	return 0;
+}


### PR DESCRIPTION
ビルトインコマンドunsetを再現した関数を実装しました。
エラー時、コマンド終了後の処理は未実装です。