### PR TITLE
[fix] tokenize() 修正

### DIFF
--- a/srcs/tokenizer/tokenize.c
+++ b/srcs/tokenizer/tokenize.c
@@ -8,6 +8,36 @@
 */
 
 /*
+** 現在読み込んだindexまでがクォート中にあるかないかを返す。
+*/
+
+static bool		is_inquote(char *p, int len)
+{
+	int		quote_count;
+	int		i;
+	int		j;
+	char	quote;
+
+	i = 0;
+	while (p[i] != '\0' && i < len)
+	{
+		if (p[i] == '\'' || p[i] == '"')
+		{
+			quote = p[i];
+			j = 1;
+			while (i + j < len && p[i + j] != quote)
+				j++;
+			if (i + j == len)
+				return (true);
+			i += j + 1;
+			continue ;
+		}
+		i++;
+	}
+	return (false);
+}
+
+/*
 ** スペース区切り文字を見つけてインデックスを返す。"'の中身はそのまま渡す。
 */
 
@@ -22,12 +52,7 @@ static int		get_index(char *p)
 	{
 		while (p[i] != '\0' && !ft_strchr(" |><;", p[i]))
 			i++;
-		j = 0;
-		quote_count = 0;
-		while (j < i)
-			if (ft_strchr("\"'", p[j++]))
-				quote_count++;
-		if (quote_count % 2 == 1)
+		if (is_inquote(p, i))
 		{
 			while (p[i] != '\0' && !ft_strchr("\"'", p[i]))
 				i++;

--- a/srcs/tokenizer/tokenize.c
+++ b/srcs/tokenizer/tokenize.c
@@ -29,8 +29,7 @@ static bool		is_inquote(char *p, int len)
 				j++;
 			if (i + j == len)
 				return (true);
-			i += j + 1;
-			continue ;
+			i += j;
 		}
 		i++;
 	}
@@ -50,7 +49,7 @@ static int		get_index(char *p)
 	i = 0;
 	while (p[i] != '\0')
 	{
-		while (p[i] != '\0' && !ft_strchr(" |><;", p[i]))
+		while (!ft_strchr(" |><;", p[i]))
 			i++;
 		if (is_inquote(p, i))
 		{
@@ -81,8 +80,8 @@ static char		**check_lasttoken(char **tokens, char *op)
 	j = 0;
 	while (ft_isdigit(tokens[i][j]))
 		j++;
-	if (tokens[i][j] == '\0' ||
-		(tokens[i][j] == '>' && tokens[i][j + 1] == '\0'))
+	if (tokens[i][j] == '\0' || \
+	(ft_strchr("<>", tokens[i][j]) && tokens[i][j + 1] == '\0'))
 	{
 		tmp = tokens[i];
 		tokens[i] = ft_strjoin(tokens[i], op);
@@ -104,9 +103,7 @@ static char		*put_op_token(char ***tokens, char *p)
 		return (p);
 	}
 	if (*p == '>' || *p == '<')
-	{
 		*tokens = check_lasttoken(*tokens, ft_substr(p, 0, 1));
-	}
 	else
 		*tokens = add_str_to_list(*tokens, ft_substr(p, 0, 1));
 	if (*tokens == NULL)

--- a/tests/tokenizer/test_tokenize.c
+++ b/tests/tokenizer/test_tokenize.c
@@ -6,7 +6,7 @@ int main(void)
 	char **tokens;
 	int i;
 
-	line = ft_strdup("\"abc' d\" \"w'o'r'l'd's\"hello'test string'test 12.34>outfile 500>>outfile2");
+	line = ft_strdup("\"abc' d\" \"w'o'r'l'd's\" \' a \' b \''\' c \' hello'test string'test 12.34>outfile 500<< >>>outfile2\"'");
 	//line = ft_strdup("$A \"world, $USER\" 3>outfile1| ls $HOME;");
 	tokens = tokenize(line);
 	i = 0;

--- a/tests/tokenizer/test_tokenize.c
+++ b/tests/tokenizer/test_tokenize.c
@@ -6,7 +6,7 @@ int main(void)
 	char **tokens;
 	int i;
 
-	line = ft_strdup("\"a a a a\" \"world\"hello'test string'test 12.34>outfile 500>>outfile2");
+	line = ft_strdup("\"abc' d\" \"w'o'r'l'd's\"hello'test string'test 12.34>outfile 500>>outfile2");
 	//line = ft_strdup("$A \"world, $USER\" 3>outfile1| ls $HOME;");
 	tokens = tokenize(line);
 	i = 0;


### PR DESCRIPTION
クォート中に奇数個クォートが含まれているときの処理を修正しました。
修正前は"world's"のようなトークンを正しく認識できていませんでした。