### PR TITLE
[fix,update] normV3に備えたコードの修正、エラー出力機能追加

### DIFF
--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -7,7 +7,8 @@ static t_command	*get_command(char **strs)
 
 	if (!strs)
 		return (NULL);
-	if ((cmd = create_new_tcommand()) == NULL)
+	cmd = create_new_tcommand();
+	if (cmd == NULL)
 		return (NULL);
 	i = 0;
 	while (strs[i] != NULL)
@@ -16,13 +17,12 @@ static t_command	*get_command(char **strs)
 		{
 			if (!set_redirection_list(cmd, strs + i))
 				return (wrap_free_commands_list(cmd));
-			if (ft_strchr(strs[i + 1], '<') || ft_strchr(strs[i + 1], '>'))
-				i++;
 			i += 2;
 		}
 		else
 		{
-			if ((cmd->argv = add_str_to_list(cmd->argv, strs[i++])) == NULL)
+			cmd->argv = add_str_to_list(cmd->argv, strs[i++]);
+			if (cmd->argv == NULL)
 				return (wrap_free_commands_list(cmd));
 		}
 	}
@@ -38,10 +38,21 @@ static t_command	*get_pipeline(char **strs)
 		return (NULL);
 	if ((i = strschr(strs, "|")) < 0)
 		return (get_command(strs));
-	if ((pipeline = get_pipeline(get_strs(strs, i))) == NULL)
+	pipeline = NULL;
+	if (i == 0)
+		printf("bash: syntax error near unexpected token `%s'\n", strs[i]);
+	else
+		pipeline = get_pipeline(get_strs(strs, i));
+	if (pipeline == NULL)
 		return (NULL);
 	pipeline->op = PIPELINE;
-	if ((pipeline->next = get_pipeline(get_strs(strs + i + 1, 0))) == NULL)
+	if (strs[i + 1] == NULL)
+	{
+		printf("bash: syntax error near unexpected token `%s'\n", strs[i]);
+		return (NULL);
+	}
+	pipeline->next = get_pipeline(get_strs(strs + i + 1, 0));
+	if (pipeline->next == NULL)
 		return (wrap_free_commands_list(pipeline));
 	pipeline->next->receive_pipe = true;
 	return (pipeline);
@@ -57,14 +68,25 @@ static t_command	*get_andor(char **strs)
 	if ((i = strschr(strs, "&|")) < 0 || (!ft_strchr(strs[i + 1], '&') && \
 	!ft_strchr(strs[i + 1], '|')))
 		return (get_pipeline(strs));
-	if ((andor = get_andor(get_strs(strs, i))) == NULL)
+	andor = NULL;
+	if (i == 0)
+		printf("bash: syntax error near unexpected token `%s'\n", strs[i]);
+	else
+		andor = get_andor(get_strs(strs, i));
+	if (andor == NULL)
 		return (NULL);
 	/*if (ft_strchr(strs[i + 1], '&'))
 	**	andor.? = AND;
 	**else
 	**	andor.? = PIPELINE;
 	*/
-	if ((andor->next = get_andor(get_strs(strs + i + 1, 0))) == NULL)
+	if (strs[i + 1] == NULL)
+	{
+		printf("bash: syntax error near unexpected token `%s'\n", strs[i]);
+		return (NULL);
+	}
+	andor->next = get_andor(get_strs(strs + i + 1, 0));
+	if (andor->next == NULL)
 		return (wrap_free_commands_list(andor));
 	return (andor);
 }
@@ -78,14 +100,23 @@ static t_command	*get_list(char **strs)
 		return (NULL);
 	if ((i = strschr(strs, ";&")) < 0)
 		return (get_andor(strs));
-	if ((list = get_list(get_strs(strs, i))) == NULL)
+	list = NULL;
+	if (i == 0)
+		printf("bash: syntax error near unexpected token `%s'\n", strs[i]);
+	else
+		list = get_list(get_strs(strs, i));
+	if (list == NULL)
 		return (NULL);
 	if (ft_strchr(strs[i], ';'))
 		list->op = SCOLON;
 	/*else
 	**	list->op = AND;
 	*/
-	if ((list->next = get_list(get_strs(strs + i + 1, 0))) == NULL)
+	if (strs[i + 1] == NULL)
+		printf("bash: syntax error near unexpected token `%s'\n", strs[i]);
+	else
+		list->next = get_list(get_strs(strs + i + 1, 0));
+	if (list->next == NULL)
 		return (wrap_free_commands_list(list));
 	return (list);
 }
@@ -103,6 +134,8 @@ t_command			*get_commandline(char **strs)
 		cmds = get_list(get_strs(strs, -1));
 	else
 		cmds = get_list(strs);
+	if (cmds == NULL)
+		return (NULL);
 	head = cmds;
 	while (cmds->next)
 		cmds = cmds->next;

--- a/srcs/parser/parser_utils.c
+++ b/srcs/parser/parser_utils.c
@@ -22,13 +22,16 @@ char	**get_strs(char **list, int len)
 	{
 		while (list[i] != NULL)
 			i++;
-		len = i + len;
+		len += i;
 	}
 	newlist = NULL;
 	i = 0;
 	while (list[i] != NULL && i < (size_t)len)
-		if ((newlist = add_str_to_list(newlist, list[i++])) == NULL)
+	{
+		newlist = add_str_to_list(newlist, list[i++]);
+		if (newlist == NULL)
 			return (NULL);
+	}
 	return (newlist);
 }
 
@@ -44,10 +47,8 @@ int		strschr(char **strs, char *set)
 	{
 		j = 0;
 		while (set[j])
-		{
 			if (ft_strchr(strs[i], set[j++]))
 				return (i);
-		}
 		i++;
 	}
 	return (-1);
@@ -61,28 +62,28 @@ void	*wrap_free_commands_list(t_command *cmds)
 
 bool	set_redirection_list(t_command *cmd, char **list)
 {
+	char	**target;
+
 	if (ft_strchr(*list, '<'))
-	{
-		if (!(cmd->redirect_in = add_str_to_list(cmd->redirect_in, list[0])))
-			return (false);
-		if (!(cmd->redirect_in = add_str_to_list(cmd->redirect_in, list[1])))
-			return (false);
-		/*if (ft_strchr(list[1], '<'))
-		**	if (!(cmd->redirect_in = \
-		**add_str_to_list(cmd->redirect_in, list[2])))
-		**		return (false);
-		*/
-	}
+		target = cmd->redirect_in;
 	else if (ft_strchr(*list, '>'))
+		target = cmd->redirect_out;
+	else
+		return (false);
+	if (ft_strchr(list[1], '<') || ft_strchr(list[1], '>'))
 	{
-		if (!(cmd->redirect_out = add_str_to_list(cmd->redirect_out, list[0])))
-			return (false);
-		if (!(cmd->redirect_out = add_str_to_list(cmd->redirect_out, list[1])))
-			return (false);
-		if (ft_strchr(list[1], '>'))
-			if (!(cmd->redirect_out = \
-			add_str_to_list(cmd->redirect_out, list[2])))
-				return (false);
+		printf("bash: syntax error near unexpected token `%s'\n", list[1]);
+		return (false);
 	}
+	target = add_str_to_list(target, list[0]);
+	if (target == NULL)
+		return (false);
+	target = add_str_to_list(target, list[1]);
+	if (target == NULL)
+		return (false);
+	if (ft_strchr(*list, '<'))
+		cmd->redirect_in = target;
+	else
+		cmd->redirect_out = target;
 	return (true);
 }

--- a/srcs/utils/add_str_to_list.c
+++ b/srcs/utils/add_str_to_list.c
@@ -13,18 +13,21 @@ char	**add_str_to_list(char **list, const char *str)
 	size_t	i;
 	char	*new_str;
 
-	if ((new_str = ft_strdup(str)) == NULL)
+	new_str = ft_strdup(str);
+	if (new_str == NULL)
 		return (list);
 	if (!list)
 	{
-		if ((list = (char **)malloc(sizeof(char *))) == NULL)
+		list = (char **)malloc(sizeof(char *));
+		if (list == NULL)
 			return (NULL);
 		list[0] = NULL;
 	}
 	i = 0;
 	while (list[i] != NULL)
 		i++;
-	if (!(list = (char **)ft_sprealloc(list, sizeof(char *) * (i + 2))))
+	list = (char **)ft_sprealloc(list, sizeof(char *) * (i + 2));
+	if (list == NULL)
 		return (NULL);
 	list[i] = new_str;
 	list[i + 1] = NULL;

--- a/tests/parser/test_parser.c
+++ b/tests/parser/test_parser.c
@@ -13,19 +13,25 @@ void	print_tcommand_iterate(t_command *cmds)
 	}
 }
 
-int		main(void)
+void	print_strs(char **strs)
+{
+	size_t i = 0;
+	while (strs[i] != NULL)
+		printf("%s ", strs[i++]);
+	puts("");
+}
+
+int		main(int argc, char **argv)
 {
 	t_command	*cmd;
-	char		*list1[19] = {"echo", "hello", ">", "file1", ">", "file2", "world", ";", "cat", "<", "file2", "|", "head", "-n", "1", "|", "wc", ";", NULL};
-	char		*list2[3] = {"echo", "hello", NULL};
+	char		**token;
+	(void)argc;
 
-	puts("test1\n");
-	if ((cmd = get_commandline(list1)) != NULL)
+	token = tokenize(argv[1]);
+	print_strs(token);
+	if ((cmd = get_commandline(token)) != NULL)
 		print_tcommand_iterate(cmd);
 	free_commandslist(&cmd);
-	puts("\n\ntest2\n");
-	if ((cmd = get_commandline(list2)) != NULL)
-		print_tcommand_iterate(cmd);
-	free_commandslist(&cmd);
+	ft_free_split(token);
 	return (0);
 }


### PR DESCRIPTION
if文の中で代入を行わないようにしました。入力が不正な時にbashと同じエラー出力をするように変更しました。
また、全てのボーナスに対応させています。

いくつかのケースでbashと異なるエラーメッセージが出てしまうことを確認しています。

・";;;;"のように区切り文字が空白無しで連続している時
・"><><>"のようにリダイレクト文字が連続している時
・"| ; | ; |"のように別の区切り文字が交互に繰り返される時

いずれもtokenizerの実装を書き換え、パーサーに渡る文字列を変更する方が作業が簡単だと思いましので一旦マージできれば、と考えています。