### PR TITLE
[fix]コマンド実行時エラー出力追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/execute/execute_parallel.c \
 			srcs/execute/start_commands.c \
 			srcs/execute/read_command.c \
+			srcs/execute/error_execute.c \
 			srcs/builtin/execute_env.c \
 			srcs/builtin/execute_unset.c \
 			srcs/tokenizer/tokenize.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -64,6 +64,7 @@ char		*join_path(char *cmd);
 void		execute_sequential(t_command *cmd);
 void		execute_parallel(t_command *cmd);
 void		start_commands(t_command *cmd);
+int			error_execute(char *path);
 
 //builtin
 void		execute_env(t_command *cmd);

--- a/srcs/builtin/execute_builtin.c
+++ b/srcs/builtin/execute_builtin.c
@@ -4,13 +4,13 @@ void	execute_builtin(t_command *cmd)
 {
 	int			ret;
 	const void	(*builtinfunc[7])(t_command*) = {
-		execute_echo(),
-		execute_cd(),
-		execute_pwd(),
-		execute_export(),
-		execute_unset(),
-		execute_env(),
-		execute_exit()
+		execute_echo,
+		execute_cd,
+		execute_pwd,
+		execute_export,
+		execute_unset,
+		execute_env,
+		execute_exit
 	};
 
 	ret = is_builtin(cmd);

--- a/srcs/execute/error_execute.c
+++ b/srcs/execute/error_execute.c
@@ -5,11 +5,13 @@ int		error_execute(char *path)
 	ft_putstr_fd("bash: ", 2);
 	ft_putstr_fd(path, 2);
 	ft_putstr_fd(": ", 2);
-	if (errno == 14)
+	if (errno == EFAULT)
 		ft_putendl_fd("command not found", 2);
 	else
 		ft_putendl_fd(strerror(errno), 2);
-	if (errno == 13)
+	if (errno == EACCES)
 		return (126);
-	return (127);
+	if (errno == EFAULT)
+		return (127);
+	return (1);
 }

--- a/srcs/execute/error_execute.c
+++ b/srcs/execute/error_execute.c
@@ -1,0 +1,15 @@
+#include "minishell.h"
+
+int		error_execute(char *path)
+{
+	ft_putstr_fd("bash: ", 2);
+	ft_putstr_fd(path, 2);
+	ft_putstr_fd(": ", 2);
+	if (errno == 14)
+		ft_putendl_fd("command not found", 2);
+	else
+		ft_putendl_fd(strerror(errno), 2);
+	if (errno == 13)
+		return (126);
+	return (127);
+}

--- a/srcs/execute/execute_parallel.c
+++ b/srcs/execute/execute_parallel.c
@@ -1,8 +1,9 @@
 #include "minishell.h"
 
-static void	execute_child(t_command *cmd, int newpipe[2])
+static void	parallel_childproc(t_command *cmd, int newpipe[2])
 {
 	extern char	**environ;
+	int			ret;
 
 	send_pipeline(cmd, newpipe);
 	receive_pipeline(cmd);
@@ -10,13 +11,16 @@ static void	execute_child(t_command *cmd, int newpipe[2])
 	redirect_output(cmd);
 	if (is_builtin(cmd) != -1)
 	{
-		execute_builtin(cmd);
-		exit(store_exitstatus(1, 0));
+		//execute_builtin(cmd);
+		//exit(store_exitstatus(1, 0));
+		exit(EXIT_SUCCESS);
 	}
 	if (has_slash(cmd->argv[0]))
-		execve(cmd->argv[0], cmd->argv, environ);
-	execve(get_cmd_frompath(cmd), cmd->argv, environ);
-	//execveのエラーキャッチ
+		ret = execve(cmd->argv[0], cmd->argv, environ);
+	else
+		ret = execve(get_cmd_frompath(cmd), cmd->argv, environ);
+	ret = error_execute(cmd->argv[0]);
+	exit(ret);
 }
 
 void		execute_parallel(t_command *cmd)
@@ -27,7 +31,7 @@ void		execute_parallel(t_command *cmd)
 		pipe(newpipe);
 	cmd->pid = fork();
 	if (cmd->pid == 0)
-		execute_child(cmd, newpipe);
+		parallel_childproc(cmd, newpipe);
 	if (cmd->receive_pipe == true)
 	{
 		close(cmd->lastfd[0]);

--- a/srcs/execute/execute_parallel.c
+++ b/srcs/execute/execute_parallel.c
@@ -10,13 +10,13 @@ static void	execute_child(t_command *cmd, int newpipe[2])
 	redirect_output(cmd);
 	if (is_builtin(cmd) != -1)
 	{
-		//execute_builtin(cmd);
-		printf("this command is builtin.\n");
-		exit(EXIT_SUCCESS);//call exit func
+		execute_builtin(cmd);
+		exit(store_exitstatus(1, 0));
 	}
 	if (has_slash(cmd->argv[0]))
-		execve(join_path(cmd->argv[0]), cmd->argv, environ);
+		execve(cmd->argv[0], cmd->argv, environ);
 	execve(get_cmd_frompath(cmd), cmd->argv, environ);
+	//execveのエラーキャッチ
 }
 
 void		execute_parallel(t_command *cmd)

--- a/srcs/execute/execute_sequential.c
+++ b/srcs/execute/execute_sequential.c
@@ -10,9 +10,8 @@ void	execute_sequential(t_command *cmd)
 	redirect_output(cmd);
 	if (is_builtin(cmd) != -1)
 	{
-		//execute_builtin(cmd);
-		printf("this command is builtin.\n");
-		return ; //call read_command
+		execute_builtin(cmd);
+		return ;
 	}
 	cmd->pid = fork();
 	//if (cmd->pid == -1)
@@ -20,7 +19,7 @@ void	execute_sequential(t_command *cmd)
 	if (cmd->pid == 0)
 	{
 		if (has_slash(cmd->argv[0]))
-			execve(join_path(cmd->argv[0]), cmd->argv, environ);
+			execve(cmd->argv[0], cmd->argv, environ);
 		execve(get_cmd_frompath(cmd), cmd->argv, environ);
 	}
 	return ;

--- a/srcs/execute/execute_sequential.c
+++ b/srcs/execute/execute_sequential.c
@@ -1,26 +1,31 @@
 #include "minishell.h"
 
-//エラー時、bool型等を返して判定する？
-
-void	execute_sequential(t_command *cmd)
+static void	sequential_chlidproc(t_command *cmd)
 {
 	extern char	**environ;
+	int			ret;
 
+	if (has_slash(cmd->argv[0]))
+		ret = execve(cmd->argv[0], cmd->argv, environ);
+	else
+		ret = execve(get_cmd_frompath(cmd), cmd->argv, environ);
+	ret = error_execute(cmd->argv[0]);
+	exit(ret);
+}
+
+void		execute_sequential(t_command *cmd)
+{
 	redirect_input(cmd);
 	redirect_output(cmd);
 	if (is_builtin(cmd) != -1)
 	{
-		execute_builtin(cmd);
+		//execute_builtin(cmd);
 		return ;
 	}
 	cmd->pid = fork();
 	//if (cmd->pid == -1)
 	//	;//error
 	if (cmd->pid == 0)
-	{
-		if (has_slash(cmd->argv[0]))
-			execve(cmd->argv[0], cmd->argv, environ);
-		execve(get_cmd_frompath(cmd), cmd->argv, environ);
-	}
+		sequential_chlidproc(cmd);
 	return ;
 }

--- a/srcs/execute/read_command.c
+++ b/srcs/execute/read_command.c
@@ -21,6 +21,6 @@ char	*read_command(void)
 		printf("exit\n");
 		exit(EXIT_SUCCESS);
 	}
-	buf[rdbyte] = '\0';
+	buf[rdbyte - 1] = '\0';
 	return (buf);
 }

--- a/srcs/execute/start_commands.c
+++ b/srcs/execute/start_commands.c
@@ -49,5 +49,5 @@ void		start_commands(t_command *cmd)
 		cmd = cmd->next;
 	}
 	free_commandslist(&cmd);
-	return ;//call read_command func
+	return ;
 }

--- a/srcs/main/main.c
+++ b/srcs/main/main.c
@@ -1,8 +1,5 @@
 #include "minishell.h"
 
-/*
-** main関数（仮）
-*/
 #define RED		"\033[31m"
 #define GREEN	"\033[32m"
 #define YELLOW	"\033[33m"
@@ -12,37 +9,33 @@
 #define WHITE	"\033[37m"
 #define RESET	"\033[m"
 
-static char *get_username()
+static void	wait_command()
 {
-	extern char **environ;
-	char *username;
+	char		*line;
+	char		**tokens;
+	t_command	*cmd;
 
-	while (*environ != NULL)
-	{
-		if (!ft_strncmp(*environ, "USER=", 5))
-		{
-			username = ft_substr(*environ, 5, ft_strlen(*environ) - 5);
-			return (username);
-		}
-	}
-	return (NULL);
+	write(1, "\033[34mminishell\033[m > ",21);
+	line = read_command();
+	//add_history(NULL, line);
+	tokens = tokenize(line);
+	cmd = get_commandline(tokens);
+	start_commands(cmd);
+	return ;
 }
 
 int main(void)
 {
-	char *username;
-
-	printf("this is color test.\n");
-	printf("%sRED%s     %sGREEN%s\n", RED, RESET, GREEN, RESET);
-	printf("%sYELLOW%s  %sBLUE%s\n", YELLOW, RESET, BLUE, RESET);
-	printf("%sMAGENTA%s %sCYAN%s\n", MAGENTA, RESET, CYAN, RESET);
-	printf("%sWHITE%s   RESET\n", WHITE, RESET);
+	//printf("this is color test.\n");
+	//printf("%sRED%s     %sGREEN%s\n", RED, RESET, GREEN, RESET);
+	//printf("%sYELLOW%s  %sBLUE%s\n", YELLOW, RESET, BLUE, RESET);
+	//printf("%sMAGENTA%s %sCYAN%s\n", MAGENTA, RESET, CYAN, RESET);
+	//printf("%sWHITE%s   RESET\n", WHITE, RESET);
 
 	create_newenv();
 	printf("Generating shell environment valiables ... %s[OK]%s\n", GREEN, RESET);
-	username = get_username();
-	printf("Hello %s, welcome to our minishell!\n", username);
-	//prompt表示
-	//call read_command
+	printf("Hello, welcome to our minishell!\n");
+	while(1)
+		wait_command();
 	return (0);
 }

--- a/srcs/tokenizer/tokenize.c
+++ b/srcs/tokenizer/tokenize.c
@@ -70,8 +70,6 @@ static char		**check_lasttoken(char **tokens, char *op)
 
 static char		*put_op_token(char ***tokens, char *p)
 {
-	char *tmp;
-
 	if (*p == ' ')
 	{
 		while (*p == ' ')


### PR DESCRIPTION
コマンド実行時、PATHからコマンドが見つからなかったとき、実行ファイルが存在しないとき、実行権限がないときのエラー出力を追加しました。
加えてminishellがコンパイルできるようread_command()に一時的な修正をしています。