### PR TITLE
[fix] expand_envvalのnorm対応、他。

### DIFF
--- a/srcs/parser/expand_envval.c
+++ b/srcs/parser/expand_envval.c
@@ -10,7 +10,6 @@ static int	has_dollar(char *line)
 	bool	inquote;
 
 	ret = 0;
-	puts(line);
 	inquote = false;
 	while (*line != '\0')
 	{
@@ -28,8 +27,7 @@ static int	has_dollar(char *line)
 				line++;
 			line++;
 		}
-		if (*line == '$')
-			ret++;
+		ret += (*line == '$');
 		line++;
 	}
 	return (ret);

--- a/tests/builtin/test_execute_unset.c
+++ b/tests/builtin/test_execute_unset.c
@@ -28,7 +28,8 @@ int main(void)
 	print_env();
 	puts("-------------");
 	cmd = create_new_tcommand();
-	cmd->argv = ft_split("unset,HOME,USER,INVALID",',');
+	cmd->argv = ft_split("unset,\"\",\"\",INVALID",',');
+	preprocess_command(cmd);
 	ret = execute_unset(cmd);
 	printf("%d\n", ret);
 	print_env();


### PR DESCRIPTION
expand_envval内のhas_doller()のnorm対応。また、preprocess_commandのエッジケースを発見しました。

had_doller()はコンパイルエラーを直した際にnormに遵守することを忘れていたため、書き換えました。
expand_unsetのエラー出力テストを行った際に、クオートのみの文字列が連続して続くと
エラー文が表示される回数が少なくbashとの差異が出てしまっていました。

bash

```
bash-3.2$ unset "" "" INVALID
bash: unset: `': not a valid identifier
bash: unset: `': not a valid identifier
```

minishell

```
bash-3.2$ ./test
bash: unset: `': not a valid identifier
```