### PR TITLE
execute_export()追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/builtin/execute_unset.c \
 			srcs/builtin/execute_pwd.c \
 			srcs/builtin/execute_echo.c \
+			srcs/builtin/execute_export.c \
 			srcs/tokenizer/tokenize.c \
 			srcs/history/history.c
 
@@ -73,8 +74,9 @@ TESTFILE =	tests/print_tcommand.c \
 			tests/builtin/test_execute_env.c \
 			tests/builtin/test_execute_unset.c \
 			tests/builtin/test_execute_pwd.c \
-			tests/tokenizer/test_tokenize.c \
 			tests/builtin/test_execute_echo.c \
+			tests/builtin/test_execute_export.c \
+			tests/tokenizer/test_tokenize.c \
 			tests/history/test_history.c
 
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/utils/split_line.c \
 			srcs/utils/validate_envkey.c \
 			srcs/utils/update_env.c \
+			srcs/utils/print_sorted_env.c \
 			srcs/parser/parser.c \
 			srcs/parser/parser_utils.c \
 			srcs/parser/expander.c \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/utils/validate_envkey.c \
 			srcs/utils/update_env.c \
 			srcs/utils/print_sorted_env.c \
+			srcs/utils/ft_str_sandwich.c \
 			srcs/parser/parser.c \
 			srcs/parser/parser_utils.c \
 			srcs/parser/expander.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -102,8 +102,9 @@ int				store_exitstatus(int mode, int last_status);
 void			execute_builtin(t_command *cmd);
 int				execute_echo(t_command *cmd);
 int				execute_env(t_command *cmd);
-int			  execute_unset(t_command *cmd);
+int				execute_unset(t_command *cmd);
 int				execute_pwd(t_command *cmd);
+int				execute_export(t_command *cmd);
 
 //parser
 char			*expand_envval(char *line);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -76,6 +76,7 @@ bool			update_env(char *key, char *value);
 void			sort_environ(char **a, char **b, size_t front, size_t end);
 char			**get_sorted_environ();
 int				print_sorted_env();
+char			*ft_str_sandwich(char *filling, char *bread);
 
 //parse
 char			**tokenize(char *line);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -62,17 +62,20 @@ typedef struct	s_termcap {
 t_termcap term;
 
 //utils
-t_command	*create_new_tcommand(void);
-void		free_commandslist(t_command **cmds);
-int			is_builtin(t_command *cmds);
-bool		create_newenv(void);
-bool		add_newval_to_env(const char *str);
-bool		has_slash(char *cmd);
-char		**add_str_to_list(char **list, const char *str);
-char		*read_command(void);
-char		**split_line(char *str, char *set[2]);
-bool		validate_envkey(char *key);
-bool		update_env(char *key, char *value);
+t_command		*create_new_tcommand(void);
+void			free_commandslist(t_command **cmds);
+int				is_builtin(t_command *cmds);
+bool			create_newenv(void);
+bool			add_newval_to_env(const char *str);
+bool			has_slash(char *cmd);
+char			**add_str_to_list(char **list, const char *str);
+char			*read_command(void);
+char			**split_line(char *str, char *set[2]);
+bool			validate_envkey(char *key);
+bool			update_env(char *key, char *value);
+void			sort_environ(char **a, char **b, size_t front, size_t end);
+char			**get_sorted_environ();
+int				print_sorted_env();
 
 //parse
 char			**tokenize(char *line);
@@ -114,23 +117,23 @@ bool			preprocess_command(t_command *cmd);
 void			print_tcommand(t_command cmd);
 
 
-char		**tokenize(char *line);
-char		*read_line(void);
-bool		set_terminal_setting(void);
-bool		reset_terminal_setting(void);
+char			**tokenize(char *line);
+char			*read_line(void);
+bool			set_terminal_setting(void);
+bool			reset_terminal_setting(void);
 //history
 t_history		*add_history(t_history *last_history, char *line);
 void			free_history(t_history *history);
 
 //terminal setting and termcap
-char		*read_line(void);
-bool		set_terminal_setting(void);
-bool		reset_terminal_setting(void);
-bool		init_tterm(void);
-bool		get_terminal_description(void);
-bool		set_termcapsettings(t_termcap term);
-char		*wrap_tgetstr(char *stored_cap, char *cap, char **bufaddr);
-void		free_tterm(t_termcap term);
-int			ft_putchar(int n);
+char			*read_line(void);
+bool			set_terminal_setting(void);
+bool			reset_terminal_setting(void);
+bool			init_tterm(void);
+bool			get_terminal_description(void);
+bool			set_termcapsettings(t_termcap term);
+char			*wrap_tgetstr(char *stored_cap, char *cap, char **bufaddr);
+void			free_tterm(t_termcap term);
+int				ft_putchar(int n);
 
 #endif

--- a/srcs/builtin/execute_export.c
+++ b/srcs/builtin/execute_export.c
@@ -6,30 +6,7 @@
 ** export [key=value]
 */
 
-int		print_env()
-{
-	extern char **environ;
-	char		**sorted;
-	size_t		i;
-
-	/*i = 1;
-	while (environ[i] != NULL)
-		i++;
-	sorted = (char **)malloc(sizeof(char *) * i);
-	if (sorted == NULL)
-		return (false);
-	sort_environ(environ);
-	*/
-	sorted = environ;
-	i = 0;
-	while (sorted[i] != NULL)
-		printf("declare -x %s\n", sorted[i++]);
-	return (EXIT_SUCCESS);
-}
-
-//ここから上で１ファイル
-
-int		print_error(char *message)
+static int	print_error(char *message)
 {
 	ft_putstr_fd("minishell : export: `", STDERR_FILENO);
 	ft_putstr_fd(message, STDERR_FILENO);
@@ -37,7 +14,7 @@ int		print_error(char *message)
 	return (EXIT_FAILURE);
 }
 
-bool	set_keyvalue(char *str, char **key, char **value)
+static bool	set_keyvalue(char *str, char **key, char **value)
 {
 	char	*equal;
 
@@ -59,7 +36,7 @@ bool	set_keyvalue(char *str, char **key, char **value)
 	return (true);
 }
 
-int		execute_export(t_command *cmd)
+int			execute_export(t_command *cmd)
 {
 	size_t	i;
 	int		status;
@@ -69,7 +46,7 @@ int		execute_export(t_command *cmd)
 	i = 1;
 	status = EXIT_SUCCESS;
 	if (cmd->argv[1] == NULL)
-		return (print_env());
+		return (print_sorted_env());
 	while (cmd->argv[i] != NULL)
 	{
 		key = NULL;

--- a/srcs/builtin/execute_export.c
+++ b/srcs/builtin/execute_export.c
@@ -1,0 +1,86 @@
+#include "minishell.h"
+
+/*
+** export
+** export [value]
+** export [key=value]
+*/
+
+int		print_env()
+{
+	extern char **environ;
+	char		**sorted;
+	size_t		i;
+
+	/*i = 1;
+	while (environ[i] != NULL)
+		i++;
+	sorted = (char **)malloc(sizeof(char *) * i);
+	if (sorted == NULL)
+		return (false);
+	sort_environ(environ);
+	*/
+	sorted = environ;
+	i = 0;
+	while (sorted[i] != NULL)
+		printf("declare -x %s\n", sorted[i++]);
+	return (EXIT_SUCCESS);
+}
+
+//ここから上で１ファイル
+
+int		print_error(char *message)
+{
+	ft_putstr_fd("minishell : export: `", STDERR_FILENO);
+	ft_putstr_fd(message, STDERR_FILENO);
+	ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+	return (EXIT_FAILURE);
+}
+
+bool	set_keyvalue(char *str, char **key, char **value)
+{
+	char	*equal;
+
+	equal = ft_strchr(str, '=');
+	*value = NULL;
+	if (equal)
+	{
+		*key = ft_substr(str, 0, equal - str);
+		*value = ft_strdup(equal + 1);
+	}
+	else
+		*key = ft_strdup(str);
+	if (!*key || (equal && !*value))
+	{
+		ft_putstr_fd("minishell : export : ", STDERR_FILENO);
+		ft_putendl_fd(strerror(errno), STDERR_FILENO);
+		return (false);
+	}
+	return (true);
+}
+
+int		execute_export(t_command *cmd)
+{
+	size_t	i;
+	int		status;
+	char	*key;
+	char	*value;
+
+	i = 1;
+	status = EXIT_SUCCESS;
+	if (cmd->argv[1] == NULL)
+		return (print_env());
+	while (cmd->argv[i] != NULL)
+	{
+		key = NULL;
+		value = NULL;
+		if (!set_keyvalue(cmd->argv[i], &key, &value))
+			status = EXIT_FAILURE;
+		if (!update_env(key, value))
+			status = print_error(cmd->argv[i]);
+		free(key);
+		free(value);
+		i++;
+	}
+	return (status);
+}

--- a/srcs/utils/ft_str_sandwich.c
+++ b/srcs/utils/ft_str_sandwich.c
@@ -1,0 +1,18 @@
+#include "minishell.h"
+
+char	*ft_str_sandwich(char *filling, char *bread)
+{
+	char *sandwich;
+	char *bread_with_topping;
+
+	if (!filling)
+		return (NULL);
+	if (!bread)
+		return (ft_strdup(filling));
+	bread_with_topping = ft_strjoin(bread, filling);
+	if (!bread_with_topping)
+		return (NULL);
+	sandwich = ft_strjoin(bread_with_topping, bread);
+	free(bread_with_topping);
+	return (sandwich);
+}

--- a/srcs/utils/print_sorted_env.c
+++ b/srcs/utils/print_sorted_env.c
@@ -51,7 +51,7 @@ static void	merge(char **a, char **b, size_t index[3])
 
 void		sort_environ(char **a, char **b, size_t front, size_t end)
 {
-	int mid;
+	size_t mid;
 	size_t index[3];
 
 	if (front == end || front+ 1 == end)

--- a/srcs/utils/print_sorted_env.c
+++ b/srcs/utils/print_sorted_env.c
@@ -1,0 +1,124 @@
+#include "minishell.h"
+
+#define FRONT 0
+#define	MID 1
+#define END 2
+
+static char	*get_str_literal(char *str)
+{
+	char *ptr;
+	char *value;
+
+	ptr = ft_strchr(str, '=');
+	if (ptr)
+	{
+		ptr = ft_strdup(ptr + 1);
+		value = ft_str_sandwich(ptr, "\"");
+		free(ptr);
+	}
+	else
+		value = ft_strdup(str);
+	return (value);
+}
+
+static void	merge(char **a, char **b, size_t index[3])
+{
+	size_t		i;
+	size_t		j;
+	size_t		k;
+
+	i = index[FRONT];
+	j = index[MID];
+	k = 0;
+	while (i < index[MID] && j < index[END])
+		if (ft_strncmp(a[i], a[j], ft_strlen(a[i])) < 0)
+			b[k++] = a[i++];
+		else
+			b[k++] = a[j++];
+	if (i == index[MID])
+		while (j < index[END])
+			b[k++] = a[j++];
+	if (i != index[MID])
+		while (i < index[MID])
+			b[k++] = a[i++];
+	i = 0;
+	while (i < k)
+	{
+		a[index[FRONT] + i] = b[i];
+		i++;
+	}
+}
+
+void		sort_environ(char **a, char **b, size_t front, size_t end)
+{
+	int mid;
+	size_t index[3];
+
+	if (front == end || front+ 1 == end)
+		return ;
+	mid = (front + end) / 2;
+	sort_environ(a, b, front, mid);
+	sort_environ(a, b, mid, end);
+	index[0] = front;
+	index[1] = mid;
+	index[2] = end;
+	merge(a, b, index);
+}
+
+char		**get_sorted_environ()
+{
+	extern char **environ;
+	char		**sorted;
+	char		**buf;
+	size_t		i;
+
+	i = 0;
+	while (environ[i] != NULL)
+		i++;
+	sorted = (char **)malloc(sizeof(char *) * (i + 1));
+	buf = (char **)malloc(sizeof(char *) * (i + 1));
+	if (!sorted || !buf)
+	{
+		free(sorted);
+		free(buf);
+		return (NULL);
+	}
+	i = 0;
+	while (environ[i] != NULL)
+	{
+		sorted[i] = environ[i];
+		i++;
+	}
+	//ft_memcpy(sorted, environ, i);
+	sorted[i] = NULL;
+	sort_environ(sorted, buf, 0, i);
+	free(buf);
+	return (sorted);
+}
+
+int			print_sorted_env()
+{
+	char	**sorted;
+	char	*value;
+	size_t	i;
+
+	sorted = get_sorted_environ();
+	if (sorted == NULL)
+		return (EXIT_FAILURE);
+	i = 0;
+	while (sorted[i] != NULL)
+	{
+		value = get_str_literal(sorted[i]);
+		if (!value)
+			return (EXIT_FAILURE);
+		printf("declare -x ");
+		while (*sorted[i] != '=')
+			putchar(*sorted[i]++);
+		putchar(*sorted[i]++);
+		printf("%s\n", value);
+		free(value);
+		i++;
+	}
+	free(sorted);
+	return (EXIT_SUCCESS);
+}

--- a/srcs/utils/print_sorted_env.c
+++ b/srcs/utils/print_sorted_env.c
@@ -1,24 +1,24 @@
 #include "minishell.h"
 
 #define FRONT 0
-#define	MID 1
+#define MID 1
 #define END 2
 
 static char	*get_str_literal(char *str)
 {
 	char *ptr;
-	char *value;
+	char *literal;
 
 	ptr = ft_strchr(str, '=');
 	if (ptr)
 	{
 		ptr = ft_strdup(ptr + 1);
-		value = ft_str_sandwich(ptr, "\"");
+		literal = ft_str_sandwich(ptr, "\"");
 		free(ptr);
 	}
 	else
-		value = ft_strdup(str);
-	return (value);
+		literal = ft_strdup(str);
+	return (literal);
 }
 
 static void	merge(char **a, char **b, size_t index[3])
@@ -54,7 +54,7 @@ void		sort_environ(char **a, char **b, size_t front, size_t end)
 	size_t mid;
 	size_t index[3];
 
-	if (front == end || front+ 1 == end)
+	if (front == end || front + 1 == end)
 		return ;
 	mid = (front + end) / 2;
 	sort_environ(a, b, front, mid);
@@ -65,7 +65,7 @@ void		sort_environ(char **a, char **b, size_t front, size_t end)
 	merge(a, b, index);
 }
 
-char		**get_sorted_environ()
+char		**get_sorted_environ(void)
 {
 	extern char **environ;
 	char		**sorted;
@@ -83,20 +83,14 @@ char		**get_sorted_environ()
 		free(buf);
 		return (NULL);
 	}
-	i = 0;
-	while (environ[i] != NULL)
-	{
-		sorted[i] = environ[i];
-		i++;
-	}
-	//ft_memcpy(sorted, environ, i);
+	ft_memcpy(sorted, environ, sizeof(char *) * i);
 	sorted[i] = NULL;
 	sort_environ(sorted, buf, 0, i);
 	free(buf);
 	return (sorted);
 }
 
-int			print_sorted_env()
+int			print_sorted_env(void)
 {
 	char	**sorted;
 	char	*value;

--- a/srcs/utils/update_env.c
+++ b/srcs/utils/update_env.c
@@ -5,29 +5,43 @@
 ** key = value　の形で環境変数を更新する。
 */
 
-bool	update_env(char *key, char *value)
+static char	*generate_keyvalue(char *key, char *value)
+{
+	char	*tmp;
+	char	*env;
+
+	if (!validate_envkey(key))
+		return (NULL);
+	if (!value)
+		return (ft_strdup(key));
+	tmp = ft_strjoin(key, "=");
+	if (!tmp)
+		return (NULL);
+	env = ft_strjoin(tmp, value);
+	free(tmp);
+	return (env);
+}
+
+bool		update_env(char *key, char *value)
 {
 	extern char	**environ;
 	char		*env;
-	char		*tmp;
 	bool		status;
 	size_t		i;
 
-	if (!validate_envkey(key))
-		return (false);
-	tmp = ft_strjoin(key, "=");
-	if (!tmp)
-		return (false);
-	env = ft_strjoin(tmp, value);
-	free(tmp);
+	env = generate_keyvalue(key, value);
 	if (!env)
 		return (false);
 	i = 0;
 	while (environ[i] != NULL && ft_strncmp(environ[i], key, ft_strlen(key)))
 		i++;
-	status = (environ[i] == NULL ? add_newval_to_env(env) : true);
-	(environ[i] == NULL ? free(env) : free(environ[i]));
-	if (environ[i] != NULL)
-		environ[i] = env;
-	return (status);
+	if (environ[i] == NULL)
+	{
+		status = add_newval_to_env(env);
+		free(env);
+		return (status);
+	}
+	free(environ[i]);
+	environ[i] = env;
+	return (true);
 }

--- a/tests/builtin/test_execute_export.c
+++ b/tests/builtin/test_execute_export.c
@@ -7,6 +7,7 @@ int		main(int argc, char **argv)
 	int			status;
 	char		*key;
 	char		*env;
+	extern char	**environ;
 
 	create_newenv();
 	cmd = get_commandline(argv);
@@ -27,6 +28,7 @@ int		main(int argc, char **argv)
 		free(key);
 		i++;
 	}
-	system("leaks test");
+	ft_free_split(environ);
+	while (1);
 	return (status);
 }

--- a/tests/builtin/test_execute_export.c
+++ b/tests/builtin/test_execute_export.c
@@ -1,0 +1,32 @@
+#include "minishell.h"
+
+int		main(int argc, char **argv)
+{
+	t_command	*cmd;
+	size_t		i;
+	int			status;
+	char		*key;
+	char		*env;
+
+	create_newenv();
+	cmd = get_commandline(argv);
+	status = execute_export(cmd);
+	free_commandslist(&cmd);
+
+	i = 1;
+	while (i < argc)
+	{
+		key = ft_strchr(argv[i], '=');
+		if (!key)
+			key = ft_strdup(argv[i]);
+		else
+			key = ft_substr(argv[i], 0, key - argv[i]);
+		env = getenv(key);
+		if (env)
+			printf("%s=%s\n", key, env);
+		free(key);
+		i++;
+	}
+	system("leaks test");
+	return (status);
+}

--- a/tests/builtin/test_execute_export.c
+++ b/tests/builtin/test_execute_export.c
@@ -7,28 +7,28 @@ int		main(int argc, char **argv)
 	int			status;
 	char		*key;
 	char		*env;
-	extern char	**environ;
 
 	create_newenv();
-	cmd = get_commandline(argv);
+	//cmd = get_commandline(argv);
+	cmd = create_new_tcommand();
+	cmd->argv = ft_split(argv[1], ',');
 	status = execute_export(cmd);
-	free_commandslist(&cmd);
 
 	i = 1;
-	while (i < argc)
+	while (cmd->argv[i] != NULL)
 	{
-		key = ft_strchr(argv[i], '=');
+		key = ft_strchr(cmd->argv[i], '=');
 		if (!key)
-			key = ft_strdup(argv[i]);
+			key = ft_strdup(cmd->argv[i]);
 		else
-			key = ft_substr(argv[i], 0, key - argv[i]);
+			key = ft_substr(cmd->argv[i], 0, key - cmd->argv[i]);
 		env = getenv(key);
 		if (env)
 			printf("%s=%s\n", key, env);
 		free(key);
 		i++;
 	}
-	ft_free_split(environ);
-	while (1);
+	free_commandslist(&cmd);
+	system("leaks test");
 	return (status);
 }

--- a/tests/builtin/test_execute_export.sh
+++ b/tests/builtin/test_execute_export.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#export
+./test
+#export TEST
+./test TEST
+#export TEST=1
+./test TEST=1
+#export TEST=first TEST=second TEST=third
+./test TEST=first TEST=second TEST=third
+#export FIRST=1 SECOND=2 THIRD=3
+./test FIRST=1 SECOND=2 THIRD=3
+
+#export
+./test "export"
+#export TEST
+./test "export,TEST"
+#export TEST=1
+./test "export,TEST=1"
+#export TEST=first TEST=second TEST=third
+./test "export,TEST=first TEST=second TEST=third"
+#export FIRST=1 SECOND=2 THIRD=3
+./test "export,FIRST=1 SECOND=2 THIRD=3"

--- a/tests/builtin/test_execute_export.sh
+++ b/tests/builtin/test_execute_export.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+<< COMMENTOUT
+
 #export
 ./test
 #export TEST
@@ -10,6 +12,8 @@
 ./test TEST=first TEST=second TEST=third
 #export FIRST=1 SECOND=2 THIRD=3
 ./test FIRST=1 SECOND=2 THIRD=3
+
+COMMENTOUT
 
 #export
 ./test "export"


### PR DESCRIPTION
tests/builtin/test_execute_export.shを使用してテストを行えます。
```
export
export [key]
export [key = value]
```
以上のパターンに対応しています。

メモリリークについては、update_env.c内で一件残っていますが詳しい原因は調査中です。