### PR TITLE
[add]wrap_exit追加、メモリリーク解消

### DIFF
--- a/srcs/builtin/execute_exit.c
+++ b/srcs/builtin/execute_exit.c
@@ -54,7 +54,7 @@ static long long	ft_atoll(const char *nptr)
 		{
 			sign = print_error(copy);
 			ft_putstr_fd(": numeric argument required\n", STDERR_FILENO);
-			exit(sign);
+			wrap_exit(sign);
 		}
 		num = num * 10 + *nptr - '0';
 		nptr++;
@@ -73,17 +73,18 @@ int					execute_exit(t_command *cmd)
 	if (str == NULL)
 	{
 		ft_putendl_fd("exit", STDOUT_FILENO);
-		exit(EXIT_SUCCESS);
+		wrap_exit(EXIT_SUCCESS);
 	}
 	if (!is_digits(str))
 	{
 		exit_status = print_error(str);
 		ft_putendl_fd(": numeric argument required", STDERR_FILENO);
-		exit(exit_status);
+		wrap_exit(exit_status);
 	}
 	if (cmd->argv[(!ft_strncmp(cmd->argv[1], "--", 3)) + 2] != NULL)
-		exit(print_error("too many arguments\n"));
+		wrap_exit(print_error("too many arguments\n"));
 	exit_status = ft_atoll(str);
 	ft_putendl_fd("exit", STDOUT_FILENO);
-	exit(exit_status % 256);
+	wrap_exit(exit_status % 256);
+	return (EXIT_FAILURE);
 }

--- a/srcs/builtin/execute_unset.c
+++ b/srcs/builtin/execute_unset.c
@@ -39,13 +39,13 @@ static void	copy_environ(char **new_env, int target_i, int len)
 	int			i;
 
 	env_p = environ;
+	free(environ[target_i]);
 	i = 0;
 	while (i < len - 1)
 	{
 		if (i == target_i)
 		{
 			env_p++;
-			free(environ[i]);
 			target_i = -1;
 			continue ;
 		}

--- a/srcs/utils/add_str_to_list.c
+++ b/srcs/utils/add_str_to_list.c
@@ -8,6 +8,24 @@
 **strがnullの場合　listを返す
 */
 
+char	**copy_currentlist(char **list, size_t size)
+{
+	char	**new;
+	int		i;
+
+	new = malloc(size);
+	if (!new)
+		return (NULL);
+	i = 0;
+	while (list[i] != NULL)
+	{
+		new[i] = list[i];
+		i++;
+	}
+	free(list);
+	return (new);
+}
+
 char	**add_str_to_list(char **list, const char *str)
 {
 	size_t	i;
@@ -26,7 +44,7 @@ char	**add_str_to_list(char **list, const char *str)
 	i = 0;
 	while (list[i] != NULL)
 		i++;
-	list = (char **)ft_sprealloc(list, sizeof(char *) * (i + 2));
+	list = copy_currentlist(list, sizeof(char *) * (i + 2));
 	if (list == NULL)
 		return (NULL);
 	list[i] = new_str;

--- a/srcs/utils/wrap_exit.c
+++ b/srcs/utils/wrap_exit.c
@@ -1,0 +1,11 @@
+#include "minishell.h"
+
+void	wrap_exit(unsigned int status)
+{
+	extern char			**environ;
+	extern t_termcap	term;
+
+	ft_free_split(environ);
+	free_tterm(term);
+	exit(status);
+}


### PR DESCRIPTION
execute_exitからexitする際、現在の実装で解放できるヒープを開放するよう変更しました。
併せてexecute_unsetのメモリリークを修正しています。