### PR TITLE
[fix]norm対応、コンパイルエラー修正など

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -21,25 +21,25 @@
 # define LOAD			1
 # define BUFFER_SIZE	2048
 
-typedef enum	e_op {
+typedef enum e_op {
 	EOS,
 	PIPELINE,
 	SCOLON
-}				t_op;
+}	t_op;
 
-typedef enum	e_dir {
+typedef enum e_dir {
 	PREV,
 	NEXT
-}				t_dir;
+}	t_dir;
 
-typedef struct	s_hist {
+typedef struct s_hist {
 	struct s_hist	*next;
 	struct s_hist	*prev;
 	char			*line;
 	char			*modified_line;
-}				t_hist;
+}	t_hist;
 
-typedef struct	s_command {
+typedef struct s_command {
 	struct s_command	*next;
 	char				**argv;
 	char				**redirect_in;
@@ -50,19 +50,19 @@ typedef struct	s_command {
 	bool				has_childproc;
 	pid_t				pid;
 	int					exitstatus;
-}				t_command;
+}	t_command;
 
-typedef struct	s_termcap {
-	char *term_buf;
-	char *string_buf;
-	char *buf_ptr;
-	char *ce;
-	char *dc;
-	char *DC;
-	char *le;
-}				t_termcap;
+typedef struct s_termcap {
+	char	*term_buf;
+	char	*string_buf;
+	char	*buf_ptr;
+	char	*ce;
+	char	*dc;
+	char	*DC;
+	char	*le;
+}	t_termcap;
 
-t_termcap term;
+t_termcap	term;
 
 //utils
 t_command		*create_new_tcommand(void);
@@ -77,8 +77,8 @@ char			**split_line(char *str, char *set[2]);
 bool			validate_envkey(char *key);
 bool			update_env(char *key, char *value);
 void			sort_environ(char **a, char **b, size_t front, size_t end);
-char			**get_sorted_environ();
-int				print_sorted_env();
+char			**get_sorted_environ(void);
+int				print_sorted_env(void);
 void			wrap_exit(unsigned int status);
 
 //parse

--- a/srcs/main/main.c
+++ b/srcs/main/main.c
@@ -44,7 +44,7 @@ static void	wait_command(t_hist **hist)
 		return ;
 	tokens = tokenize(line);
 	free(line);
-	cmd = get_commandline(tokens);
+	cmd = parse(tokens);
 	ft_free_split(tokens);
 	if (cmd == NULL)
 		return ;

--- a/srcs/parser/parser_utils.c
+++ b/srcs/parser/parser_utils.c
@@ -36,14 +36,12 @@ char	**get_strs(char **list, int len)
 int	strsncmp(char **strs, char *set)
 {
 	size_t	i;
-	size_t	j;
 
 	if (!strs || !set)
 		return (-1);
 	i = 0;
 	while (strs[i] != NULL)
 	{
-		j = 0;
 		if (!ft_strncmp(strs[i], set, 2))
 			return (i);
 		i++;

--- a/srcs/tokenizer/validate_line.c
+++ b/srcs/tokenizer/validate_line.c
@@ -12,7 +12,7 @@
 
 static bool	error_return(char *line, char last_op, bool has_space)
 {
-	const char *newline = "newline";
+	const char	*newline = "newline";
 
 	ft_putstr_fd("minishell: syntax error near unexpected token `", 2);
 	if (*line == last_op && !has_space)

--- a/srcs/utils/add_str_to_list.c
+++ b/srcs/utils/add_str_to_list.c
@@ -16,6 +16,8 @@ char	**copy_currentlist(char **list, size_t size)
 	new = malloc(size);
 	if (!new)
 		return (NULL);
+	if (list == NULL)
+		return (new);
 	i = 0;
 	while (list[i] != NULL)
 	{


### PR DESCRIPTION
ヘッダーのnorm対応、コンパイルエラー、add_str_to_listのエラーを修正しました。
ヘッダーのグローバル変数の命名は#100とこのプルリクが取り込まれてから変更します。