### PR TITLE
[fix]error_execute修正

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -138,7 +138,7 @@ char			*display_history(char *line, char *c, int *i, t_hist **hist);
 bool			update_history(char *line, t_hist **hist_p);
 
 //error output
-int				error_execute(char *path);
+int				error_execute(char *path, int last_errno);
 int				error_fork(void);
 bool			redirect_error(char *key, char *errmsg);
 bool			fd_error(long fd, char *errmsg);

--- a/srcs/execute/error_execute.c
+++ b/srcs/execute/error_execute.c
@@ -1,17 +1,17 @@
 #include "minishell.h"
 
-int	error_execute(char *path)
+int	error_execute(char *path, int last_errno)
 {
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(path, STDERR_FILENO);
 	ft_putstr_fd(": ", STDERR_FILENO);
-	if (errno == EFAULT)
+	if (last_errno == EFAULT)
 		ft_putendl_fd("command not found", STDERR_FILENO);
 	else
-		ft_putendl_fd(strerror(errno), STDERR_FILENO);
-	if (errno == EACCES)
+		ft_putendl_fd(strerror(last_errno), STDERR_FILENO);
+	if (last_errno == EACCES)
 		return (126);
-	if (errno == ENOENT || errno == EFAULT)
+	if (last_errno == ENOENT || last_errno == EFAULT)
 		return (127);
 	return (1);
 }

--- a/srcs/execute/execute_parallel.c
+++ b/srcs/execute/execute_parallel.c
@@ -21,7 +21,7 @@ static void	parallel_childproc(t_command *cmd, int newpipe[2])
 		execve(cmd->argv[0], cmd->argv, environ);
 	else
 		execve(get_cmd_frompath(cmd), cmd->argv, environ);
-	exit(error_execute(cmd->argv[0]));
+	exit(error_execute(cmd->argv[0], errno));
 }
 
 int	execute_parallel(t_command *cmd)

--- a/srcs/execute/execute_sequential.c
+++ b/srcs/execute/execute_sequential.c
@@ -8,7 +8,7 @@ static void	sequential_chlidproc(t_command *cmd)
 		execve(cmd->argv[0], cmd->argv, environ);
 	else
 		execve(get_cmd_frompath(cmd), cmd->argv, environ);
-	exit(error_execute(cmd->argv[0]));
+	exit(error_execute(cmd->argv[0], errno));
 }
 
 int	execute_sequential(t_command *cmd)


### PR DESCRIPTION
error_execute関数実行中にエラーが発生したときerrnoが変更され期待した動作ができていなかった問題を修正しました。
具体的には標準エラーがdev/nullにリダイレクトされていた時errnoが9になり、終了ステータスの設定がうまく行えていませんでした。