### PR TITLE
[add]チルダ展開追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/parser/parser_utils.c \
 			srcs/expander/expander.c \
 			srcs/expander/is_empty_env.c \
+			srcs/expander/expand_tilde.c \
 			srcs/expander/expand_envval.c \
 			srcs/expander/get_envname.c \
 			srcs/expander/expand_utils.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -122,6 +122,7 @@ int				execute_exit(t_command *cmd);
 char			*expand_envval(char *line);
 void			get_envname(char *line, int *i);
 bool			is_empty_env(char ***strs, char *line, int i);
+char			*expand_firsttilde(char *arg);
 char			*expand_exitstatus(char *ret, int *i);
 char			*output_dollar(char *ret, int *i);
 bool			preprocess_command(t_command *cmd);

--- a/srcs/expander/expand_tilde.c
+++ b/srcs/expander/expand_tilde.c
@@ -9,8 +9,6 @@ static bool	has_tilde(char *line)
 
 char	*expand_firsttilde(char *arg)
 {
-	char	*ret;
-
 	if (!has_tilde(arg))
 		return (ft_strdup(arg));
 	return (ft_strjoin(getenv("HOME"), arg + 1));

--- a/srcs/expander/expand_tilde.c
+++ b/srcs/expander/expand_tilde.c
@@ -9,7 +9,6 @@ static bool	has_tilde(char *line)
 
 char	*expand_firsttilde(char *arg)
 {
-	char	*bottom;
 	char	*ret;
 
 	if (!has_tilde(arg))

--- a/srcs/expander/expand_tilde.c
+++ b/srcs/expander/expand_tilde.c
@@ -13,8 +13,5 @@ char	*expand_firsttilde(char *arg)
 
 	if (!has_tilde(arg))
 		return (ft_strdup(arg));
-	ret = ft_strjoin(getenv("HOME"), arg + 1);
-	if (ret == NULL)
-		return (NULL);
-	return (ret);
+	return (ft_strjoin(getenv("HOME"), arg + 1));
 }

--- a/srcs/expander/expand_tilde.c
+++ b/srcs/expander/expand_tilde.c
@@ -1,0 +1,21 @@
+#include "minishell.h"
+
+static bool	has_tilde(char *line)
+{
+	if (line[0] == '~' && (line[1] == '\0' || line[1] == '/'))
+		return (true);
+	return (false);
+}
+
+char	*expand_firsttilde(char *arg)
+{
+	char	*bottom;
+	char	*ret;
+
+	if (!has_tilde(arg))
+		return (ft_strdup(arg));
+	ret = ft_strjoin(getenv("HOME"), arg + 1);
+	if (ret == NULL)
+		return (NULL);
+	return (ret);
+}

--- a/srcs/expander/expander.c
+++ b/srcs/expander/expander.c
@@ -55,6 +55,8 @@ static char	*trim_quote(char *arg)
 	char	*tmp;
 	char	*ret;
 
+	if (arg == NULL)
+		return (NULL);
 	tmp = malloc(sizeof(char) * (get_len(arg) + 1));
 	if (tmp == NULL)
 		return (NULL);
@@ -80,20 +82,20 @@ static bool	preprocess_tokens(char ***strs)
 	char	*ret;
 	char	*tmp;
 
-	if ((*strs) == NULL)
-		return (true);
 	i = 0;
-	while ((*strs)[i] != NULL)
+	while ((*strs) != NULL && (*strs)[i] != NULL)
 	{
 		ret = expand_envval((*strs)[i]);
-		if (ret == NULL)
-			return (false);
-		tmp = ret;
+		if (ret == (*strs)[i])
+			ret = ft_strdup((*strs)[i]);
 		if (is_empty_env(strs, ret, i))
 			continue ;
+		tmp = ret;
+		ret = expand_firsttilde(ret);
+		free(tmp);
+		tmp = ret;
 		ret = trim_quote(ret);
-		if (tmp != (*strs)[i])
-			free(tmp);
+		free(tmp);
 		if (ret == NULL)
 			return (false);
 		free((*strs)[i]);

--- a/srcs/expander/is_empty_env.c
+++ b/srcs/expander/is_empty_env.c
@@ -27,7 +27,7 @@ bool	is_empty_env(char ***strs, char *line, int target_i)
 	int		i;
 	char	**new;
 
-	if (*line != '\0')
+	if (line == NULL || *line != '\0')
 		return (false);
 	i = 0;
 	while ((*strs)[i] != NULL)

--- a/tests/expander/test_expander.c
+++ b/tests/expander/test_expander.c
@@ -29,6 +29,11 @@ int main(int argc, char **argv)
 	store_exitstatus(SAVE, 15);
 	cmd = create_new_tcommand();
 
+	cmd->argv = ft_split("~test,~,\"~\",'~',\" ~\",~/test,test/~,~/~/,test~",',');
+	ret = preprocess_command(cmd);
+	print_splits(cmd->argv);
+	ft_free_split(cmd->argv);
+
 	cmd->argv = ft_split("echo,a,$TEST,a,$123456789USER",',');
 	ret = preprocess_command(cmd);
 	print_splits(cmd->argv);


### PR DESCRIPTION
トークン中のクォートに囲まれていないチルダを環境変数HOMEで展開する関数を追加しました。
bashにxcオプションをつけて`echo ~`等を実行すると`~`がHOMEに展開されるためcdだけでなくすべてのコマンド実行前に`~`を展開するようにしました。