### PR TITLE
[add]バックスラッシュエスケープ追加、Makefile修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/utils/update_env.c \
 			srcs/utils/print_sorted_env.c \
 			srcs/utils/wrap_exit.c \
+			srcs/utils/get_escapestr.c \
 			srcs/parser/parser.c \
 			srcs/parser/parser_utils.c \
 			srcs/expander/expander.c \
@@ -74,6 +75,7 @@ TESTFILE =	tests/print_tcommand.c \
 			tests/utils/test_split_line.c \
 			tests/utils/test_validate_envkey.c \
 			tests/utils/test_update_env.c \
+			tests/utils/test_get_escapestr.c \
 			tests/parser/test_parser.c \
 			tests/expander/test_expander.c \
 			tests/expander/test_expand_envval.c \
@@ -119,9 +121,9 @@ $(OBJDIR)/%.o: %.c
 	@mkdir -p $(BINDIRS)
 	gcc -g $(CFLAGS) $(INCLUDES) -c $< -o $@
 
-$(TEST): $(LIBFT)
+$(TEST): $(OBJECTS) $(LIBFT)
 	gcc -g $(filter tests/%/test_$@.c, $(TESTFILE)) tests/print_tcommand.c \
-	$(filter-out srcs/main/main.c ,$(SRCFILE)) $(INCLUDES) $^ -ltermcap -o test
+	$(filter-out obj/srcs/main/main.o, $^) $(INCLUDES) -ltermcap -o test
 
 clean:
 	$(MAKE) clean -C ./libft

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -83,6 +83,7 @@ void			sort_environ(char **a, char **b, size_t front, size_t end);
 char			**get_sorted_environ(void);
 int				print_sorted_env(void);
 void			wrap_exit(unsigned int status);
+char			*get_escapestr(char *line);
 
 //parse
 char			**tokenize(char *line);

--- a/srcs/builtin/execute_unset.c
+++ b/srcs/builtin/execute_unset.c
@@ -12,7 +12,7 @@ static int	error_unset(char *key, char *errmsg)
 	ft_putstr_fd("minishell: unset: `", STDERR_FILENO);
 	ft_putstr_fd(key, STDERR_FILENO);
 	ft_putendl_fd(errmsg, STDERR_FILENO);
-	return (1);
+	return (EXIT_FAILURE);
 }
 
 static int	get_target_index(char *key)

--- a/srcs/builtin/execute_unset.c
+++ b/srcs/builtin/execute_unset.c
@@ -7,12 +7,12 @@
 ** return後、execute_builtin関数で、コマンド終了時の処理を呼び出す想定で実装します。
 */
 
-void	error_unset(char *key, char *errmsg)
+static int	error_unset(char *key, char *errmsg)
 {
 	ft_putstr_fd("minishell: unset: `", STDERR_FILENO);
 	ft_putstr_fd(key, STDERR_FILENO);
 	ft_putendl_fd(errmsg, STDERR_FILENO);
-	return ;
+	return (1);
 }
 
 static int	get_target_index(char *key)
@@ -81,24 +81,26 @@ int	execute_unset(t_command *cmd)
 {
 	int		i;
 	int		ret;
+	int		key;
 
 	i = 1;
 	ret = 0;
 	while (cmd->argv[i] != NULL)
 	{
-		if (!validate_envkey(cmd->argv[i]))
+		key = get_escapestr(cmd->argv[i]);
+		if (key == NULL)
 		{
-			error_unset(cmd->argv[i], "': not a valid identifier");
-			ret = 1;
+			ret = error_unset(cmd->argv[i], "':malloc error");
+			continue ;
 		}
-		else if (getenv(cmd->argv[i]))
+		if (!validate_envkey(key))
+			ret = error_unset(cmd->argv[i], "': not a valid identifier");
+		else if (getenv(key))
 		{
-			if (!delete_key(cmd->argv[i]))
-			{
-				error_unset(cmd->argv[i], "':malloc error");
-				ret = 1;
-			}
+			if (!delete_key(key))
+				ret = error_unset(cmd->argv[i], "':malloc error");
 		}
+		free(key);
 		i++;
 	}
 	return (ret);

--- a/srcs/builtin/execute_unset.c
+++ b/srcs/builtin/execute_unset.c
@@ -81,7 +81,7 @@ int	execute_unset(t_command *cmd)
 {
 	int		i;
 	int		ret;
-	int		key;
+	char	key;
 
 	i = 1;
 	ret = 0;

--- a/srcs/builtin/execute_unset.c
+++ b/srcs/builtin/execute_unset.c
@@ -90,15 +90,15 @@ int	execute_unset(t_command *cmd)
 		key = get_escapestr(cmd->argv[i]);
 		if (key == NULL)
 		{
-			ret = error_unset(cmd->argv[i], "':malloc error");
+			ret = error_unset(key, "':malloc error");
 			continue ;
 		}
 		if (!validate_envkey(key))
-			ret = error_unset(cmd->argv[i], "': not a valid identifier");
+			ret = error_unset(key, "': not a valid identifier");
 		else if (getenv(key))
 		{
 			if (!delete_key(key))
-				ret = error_unset(cmd->argv[i], "':malloc error");
+				ret = error_unset(key, "':malloc error");
 		}
 		free(key);
 		i++;

--- a/srcs/builtin/execute_unset.c
+++ b/srcs/builtin/execute_unset.c
@@ -81,7 +81,7 @@ int	execute_unset(t_command *cmd)
 {
 	int		i;
 	int		ret;
-	char	key;
+	char	*key;
 
 	i = 1;
 	ret = 0;

--- a/srcs/utils/get_escapestr.c
+++ b/srcs/utils/get_escapestr.c
@@ -1,0 +1,43 @@
+#include "minishell.h"
+
+static int	get_len(char *line)
+{
+	int	len;
+
+	len = 0;
+	while (*line)
+	{
+		if (*line == '\\')
+		{
+			line++;
+			continue ;
+		}
+		len++;
+		line++;
+	}
+	return (len);
+}
+
+char	*get_escapestr(char *line)
+{
+	char	*str;
+	int		len;
+	int		i;
+
+	len = get_len(line);
+	str = malloc(sizeof(char) * (len + 1));
+	i = 0;
+	while (*line != '\0')
+	{
+		if (*line == '\\')
+		{
+			line++;
+			continue ;
+		}
+		str[i] = *line;
+		i++;
+		line++;
+	}
+	str[i] = '\0';
+	return (str);
+}

--- a/tests/utils/test_get_escapestr.c
+++ b/tests/utils/test_get_escapestr.c
@@ -1,0 +1,13 @@
+#include "minishell.h"
+
+int	main(int argc, char **argv)
+{
+	char	*line;
+
+	if (argc <= 1)
+		return 0;
+	line = get_escapestr(argv[1]);
+	puts(line);
+	free(line);
+	return 0;
+}


### PR DESCRIPTION
`unset TE\ST`や`export TE\ST=100`等のコマンドでkeyがTESTとして認識されるようバックスラッシュをエスケープする関数を追加しました。
またMakefileを修正しテストコンパイル時にリリンクしないよう変更しています。