### PR TITLE
[add]環境変数SHLVL追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/utils/print_sorted_env.c \
 			srcs/utils/wrap_exit.c \
 			srcs/utils/get_escapestr.c \
+			srcs/utils/update_shlvl.c \
 			srcs/parser/parser.c \
 			srcs/parser/parser_utils.c \
 			srcs/expander/expander.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -84,6 +84,7 @@ char			**get_sorted_environ(void);
 int				print_sorted_env(void);
 void			wrap_exit(unsigned int status);
 char			*get_escapestr(char *line);
+bool			update_shlvl(void);
 
 //parse
 char			**tokenize(char *line);

--- a/srcs/main/main.c
+++ b/srcs/main/main.c
@@ -82,8 +82,9 @@ int	main(int argc, char **argv)
 
 	hist = NULL;
 	create_newenv();
-	update_shlvl();
 	init_tterm();
+	if (!update_shlvl())
+		wrap_exit(EXIT_FAILURE);
 	if (argc > 2 && !ft_strncmp(argv[1], "-c", 3))
 	{
 		line = ft_strdup(argv[2]);

--- a/srcs/main/main.c
+++ b/srcs/main/main.c
@@ -82,6 +82,7 @@ int	main(int argc, char **argv)
 
 	hist = NULL;
 	create_newenv();
+	update_shlvl();
 	init_tterm();
 	if (argc > 2 && !ft_strncmp(argv[1], "-c", 3))
 	{

--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -1,0 +1,53 @@
+#include "minishell.h"
+
+//bash: warning: shell level (1001) too high, resetting to 1
+//1001は足した後の値
+static void	output_error(char *val)
+{
+	ft_putstr_fd("minishell: warning: shell level (", STDERR_FILENO);
+	ft_putstr_fd(val, STDERR_FILENO);
+	ft_putendl_fd(") too high, resetting to 1", STDERR_FILENO);
+	return ;
+}
+
+static bool	is_valid_shlvl(char *env)
+{
+	if (!ft_isdigit(*env) || *env != '+' || *env != '-')
+		return (false);
+	env++;
+	while (*env != '\0')
+	{
+		if (!ft_isdigit(*env))
+			return (false);
+		env++;
+	}
+	return (true);
+}
+
+bool	update_shlvl(void)
+{
+	extern char	**environ;
+	char		env;
+	int			value;
+	bool		ret;
+
+	env = getenv("SHLVL");
+	if (env == NULL)
+		return (add_newval_to_env("SHLVL=1"));
+	if (!is_valid_shlvl(env))
+		return (update_env("SHLVL", "1"));
+	value = ft_atoi(env);
+	if (value < 0)
+		return (update_env("SHLVL", "0"));
+	value++;
+	env = ft_itoa(value);
+	if (value >= 1001)
+	{
+		output_error(env);
+		free(env);
+		return (update_env("SHLVL", "1"));
+	}
+	ret = update_env("SHLVL", env);
+	free(env);
+	return (ret);
+}

--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -1,7 +1,5 @@
 #include "minishell.h"
 
-//bash: warning: shell level (1001) too high, resetting to 1
-//1001は足した後の値
 static void	output_error(char *val)
 {
 	ft_putstr_fd("minishell: warning: shell level (", STDERR_FILENO);
@@ -12,7 +10,7 @@ static void	output_error(char *val)
 
 static bool	is_valid_shlvl(char *env)
 {
-	if (!ft_isdigit(*env) || *env != '+' || *env != '-')
+	if (!ft_isdigit(*env) && *env != '+' && *env != '-')
 		return (false);
 	env++;
 	while (*env != '\0')

--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -24,7 +24,6 @@ static bool	is_valid_shlvl(char *env)
 
 bool	update_shlvl(void)
 {
-	extern char	**environ;
 	char		*env;
 	int			value;
 	bool		ret;
@@ -40,6 +39,8 @@ bool	update_shlvl(void)
 	if (++value == 1000)
 		return (update_env("SHLVL", ""));
 	env = ft_itoa(value);
+	if (env == NULL)
+		return (false);
 	if (value >= 1001)
 	{
 		output_error(env);

--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -27,7 +27,7 @@ static bool	is_valid_shlvl(char *env)
 bool	update_shlvl(void)
 {
 	extern char	**environ;
-	char		env;
+	char		*env;
 	int			value;
 	bool		ret;
 

--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -37,7 +37,8 @@ bool	update_shlvl(void)
 	value = ft_atoi(env);
 	if (value < 0)
 		return (update_env("SHLVL", "0"));
-	value++;
+	if (++value == 1000)
+		return (update_env("SHLVL", ""));
 	env = ft_itoa(value);
 	if (value >= 1001)
 	{

--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -36,8 +36,7 @@ bool	update_shlvl(void)
 	value = ft_atoi(env);
 	if (value < 0)
 		return (update_env("SHLVL", "0"));
-	if (++value == 1000)
-		return (update_env("SHLVL", ""));
+	value++;
 	env = ft_itoa(value);
 	if (env == NULL)
 		return (false);


### PR DESCRIPTION
環境変数SHLVLの動作を再現する関数を追加しました。
SHLVLが999の時、新しいshellを起動するとSHLVLの値が1000にならない動作については、
reference等にも記載がないので再現していません。