### PR TITLE
[fix]get_escapestr修正

### DIFF
--- a/srcs/utils/get_escapestr.c
+++ b/srcs/utils/get_escapestr.c
@@ -1,43 +1,107 @@
 #include "minishell.h"
 
-static int	get_len(char *line)
-{
-	int	len;
+//static bool	is_inquote(char *line)
+//{
+//	static bool	inquote = false;
+//
+//	if (*line != '"')
+//		return (inquote);
+//	if (inquote == false)
+//	{
+//		inquote = true;
+//		return (inquote);
+//	}
+//	inquote = false;
+//	return (inquote);
+//}
 
-	len = 0;
-	while (*line)
+static char	*copy_singlequote(char *tmp, int *index, char *line)
+{
+	int i;
+
+	i = *index;
+	tmp[i] = *line;
+	line++;
+	i++;
+	while (*line != '\'')
 	{
-		if (*line == '\\')
+		tmp[i] = *line;
+		line++;
+		i++;
+	}
+	tmp[i] = *line;
+	line++;
+	i++;
+	*index = i;
+	return (line);
+}
+
+static char	*copy_doublequote(char *tmp, int *index, char *line)
+{
+	int i;
+
+	i = *index;
+	tmp[i] = *line;
+	line++;
+	i++;
+	while (*line != '"')
+	{
+		if (*line == '\\' && *(line + 1) == '\\')
+			line++;
+		tmp[i] = *line;
+		line++;
+		i++;
+	}
+	tmp[i] = *line;
+	line++;
+	i++;
+	*index = i;
+	return (line);
+}
+
+static char	*copy_outquote(char *tmp, int *index, char *line)
+{
+	int i;
+
+	i = *index;
+	while (*line != '\'' && *line != '"')
+	{
+		if (*line == '\\' && *(line + 1) != '\\')
 		{
 			line++;
 			continue ;
 		}
-		len++;
+		if (*line == '\\' && *(line + 1) == '\\')
+			line++;
+		tmp[i] = *line;
 		line++;
+		i++;
 	}
-	return (len);
+	*index = i;
+	return (line);
 }
 
 char	*get_escapestr(char *line)
 {
+	char	*tmp;
 	char	*str;
-	int		len;
 	int		i;
 
-	len = get_len(line);
-	str = malloc(sizeof(char) * (len + 1));
+	tmp = malloc(sizeof(char) * (ft_strlen(line) + 1));
+	if (tmp == NULL)
+		return (NULL);
 	i = 0;
 	while (*line != '\0')
 	{
-		if (*line == '\\')
-		{
-			line++;
-			continue ;
-		}
-		str[i] = *line;
-		i++;
-		line++;
+		if (*line == '\'')
+			line = copy_singlequote(tmp, &i, line);
+		else if (*line == '"')
+			line = copy_doublequote(tmp, &i, line);
+		else
+			line = copy_outquote(tmp, &i, line);
 	}
-	str[i] = '\0';
+	tmp[i] = '\0';
+	str = ft_strdup(tmp);
+	free(tmp);
 	return (str);
 }

--- a/srcs/utils/get_escapestr.c
+++ b/srcs/utils/get_escapestr.c
@@ -64,7 +64,7 @@ static char	*copy_outquote(char *tmp, int *index, char *line)
 	int i;
 
 	i = *index;
-	while (*line != '\'' && *line != '"')
+	while (*line != '\0' && *line != '\'' && *line != '"')
 	{
 		if (*line == '\\' && *(line + 1) != '\\')
 		{

--- a/srcs/utils/get_escapestr.c
+++ b/srcs/utils/get_escapestr.c
@@ -17,7 +17,7 @@
 
 static char	*copy_singlequote(char *tmp, int *index, char *line)
 {
-	int i;
+	int	i;
 
 	i = *index;
 	tmp[i] = *line;
@@ -38,7 +38,7 @@ static char	*copy_singlequote(char *tmp, int *index, char *line)
 
 static char	*copy_doublequote(char *tmp, int *index, char *line)
 {
-	int i;
+	int	i;
 
 	i = *index;
 	tmp[i] = *line;
@@ -61,7 +61,7 @@ static char	*copy_doublequote(char *tmp, int *index, char *line)
 
 static char	*copy_outquote(char *tmp, int *index, char *line)
 {
-	int i;
+	int	i;
 
 	i = *index;
 	while (*line != '\0' && *line != '\'' && *line != '"')

--- a/tests/utils/test_get_escapestr.c
+++ b/tests/utils/test_get_escapestr.c
@@ -5,9 +5,9 @@ int	main()
 	char	*line;
 	char	*ret;
 
-	line = ft_strdup("h\\e\\\\l\\lo\"t\\\\es\\t\"'wo\\rl\\d'");
+	line = ft_strdup("h\\e\\\\l\\lo\"t\\\\es\\t\"'wo\\rl\\d't\\est\\");
 	printf("input : %s\n", line);
-	ret = get_escapestr("h\\e\\\\l\\lo\"t\\\\es\\t\"'wo\\rl\\d'");
+	ret = get_escapestr(line);
 	printf("output: %s\n", ret);
 	free(line);
 	free(ret);

--- a/tests/utils/test_get_escapestr.c
+++ b/tests/utils/test_get_escapestr.c
@@ -1,13 +1,15 @@
 #include "minishell.h"
 
-int	main(int argc, char **argv)
+int	main()
 {
 	char	*line;
+	char	*ret;
 
-	if (argc <= 1)
-		return 0;
-	line = get_escapestr(argv[1]);
-	puts(line);
+	line = ft_strdup("h\\e\\\\l\\lo\"t\\\\es\\t\"'wo\\rl\\d'");
+	printf("input : %s\n", line);
+	ret = get_escapestr("h\\e\\\\l\\lo\"t\\\\es\\t\"'wo\\rl\\d'");
+	printf("output: %s\n", ret);
 	free(line);
+	free(ret);
 	return 0;
 }


### PR DESCRIPTION
クォートの内外でバックスラッシュのエスケープが下記のように判定されるよう変更しました。
ダブルクォート中→　\一つはそのまま出力、\\\は\一つとして出力。
シングルクォート中→　すべてリテラルとして出力。
クォート外→　\一つはエスケープ、\\\は\一つとして出力。
