### PR TITLE
[fix]read_line修正、関数名変更

### DIFF
--- a/srcs/history/display_history.c
+++ b/srcs/history/display_history.c
@@ -8,7 +8,7 @@
 ** **histは参照したhisotryをそのまま返す。
 */
 
-static char	*error_return(char *c, char *str)
+static char	*error_dhistory(char *c, char *str)
 {
 	write(STDOUT_FILENO, "\n", 1);
 	ft_putstr_fd("minishell: display_history: ", STDERR_FILENO);
@@ -54,7 +54,7 @@ char	*display_history(char *line, char *c, int *i, t_hist **hist)
 		free((*hist)->modified_line);
 	(*hist)->modified_line = ft_strdup(line);
 	if ((*hist)->modified_line == NULL)
-		return (error_return(c, "malloc error"));
+		return (error_dhistory(c, "malloc error"));
 	if (dir == NEXT)
 		*hist = (*hist)->next;
 	else

--- a/srcs/history/update_history.c
+++ b/srcs/history/update_history.c
@@ -5,7 +5,7 @@
 ** 実行されなかったhistoryのmodified_lineはlineへ更新する。
 */
 
-static bool	error_return(char *str)
+static bool	error_uhistory(char *str)
 {
 	write(STDOUT_FILENO, "\n", 1);
 	ft_putstr_fd("minishell: update_history: ", STDERR_FILENO);
@@ -70,7 +70,7 @@ bool	update_history(char *line, t_hist **hist)
 	{
 		*hist = add_line_to_front(line, *hist);
 		if (*hist == NULL)
-			return (error_return("malloc error"));
+			return (error_uhistory("malloc error"));
 		free((*hist)->modified_line);
 		(*hist)->modified_line = NULL;
 		if ((*hist)->next == NULL)

--- a/srcs/main/read_line.c
+++ b/srcs/main/read_line.c
@@ -26,7 +26,7 @@ static char	*check_input(char *line, char *c, int *i)
 	int	n;
 
 	n = 0;
-	while (c[n] != '\0' && c[n] != '\n' && c[n] != '\034')
+	while (c[n] != '\0' && c[n] != '\n' && c[n] != '\033')
 	{
 		if (*i == BUFFER_SIZE)
 			break ;
@@ -88,7 +88,7 @@ static char	*get_line(char *line, t_hist **hist)
 
 char	*read_line(t_hist **hist)
 {
-	extern t_termcap	term;
+	//extern t_termcap	term;
 	char				*line;
 	char				*tmp;
 
@@ -100,7 +100,7 @@ char	*read_line(t_hist **hist)
 	}
 	line[0] = '\0';
 	tmp = line;
-	get_cursor_position(&term.pos[0], &term.pos[1]);
+	//get_cursor_position(&term.pos[0], &term.pos[1]);
 	line = get_line(line, hist);
 	if (!reset_terminal_setting() || !line)
 	{

--- a/srcs/main/read_line.c
+++ b/srcs/main/read_line.c
@@ -23,16 +23,7 @@ void	move_nextline(int *len)
 
 static char	*check_input(char *line, char *c, int *i, int rc)
 {
-	if (*i == BUFFER_SIZE)
-	{
-		write(STDOUT_FILENO, "\n", 1);
-		ft_putendl_fd("minishell: read_line: Too long line", STDERR_FILENO);
-		c[0] = '\n';
-		return (NULL);
-	}
-	if (!ft_strncmp(c, BACKSPACE, 2))
-		back_line(line, i);
-	else if (!ft_strncmp(c, "\v", 2) || !ft_strncmp(c, "\r", 2)
+	if (!ft_strncmp(c, "\v", 2) || !ft_strncmp(c, "\r", 2)
 		|| !ft_strncmp(c, "\f", 2) || !ft_strncmp(c, "\t", 2))
 		write(STDOUT_FILENO, "\007", 1);
 	else if (rc == 1 && c[0] != '\n' && c[0] != '\034')
@@ -44,6 +35,32 @@ static char	*check_input(char *line, char *c, int *i, int rc)
 		line[*i] = '\0';
 	}
 	return (line);
+}
+
+static bool	check_control(char *c, int *i, char *line, t_hist **hist)
+{
+	if (!ft_strncmp(c, BACKSPACE, 2)
+		|| !ft_strncmp(c, CTRL_D, 2) || !ft_strncmp(c, CTRL_C, 2)
+		|| !ft_strncmp(c, UPKEY, 4) || !ft_strncmp(c, DOWNKEY, 4))
+	{
+		if (!ft_strncmp(c, CTRL_D, 2) && *i == 0)
+			get_eof(line, hist);
+		else if (!ft_strncmp(c, CTRL_D, 2))
+			write(1, "\007", 1);
+		else if (!ft_strncmp(c, BACKSPACE, 2))
+			back_line(line, i);
+		else if (!ft_strncmp(c, CTRL_C, 2))
+			get_sigint(line, c);
+		else if (!ft_strncmp(c, UPKEY, 4) || !ft_strncmp(c, DOWNKEY, 4))
+			display_history(line, c, i, hist);
+		return (true);
+	}
+	if (*i == BUFFER_SIZE)
+	{
+		write(1, "\007", 1);
+		return (true);
+	}
+	return (false);
 }
 
 static char	*get_line(char *line, t_hist **hist)
@@ -60,15 +77,7 @@ static char	*get_line(char *line, t_hist **hist)
 		if (rc == -1)
 			return (NULL);
 		c[rc] = '\0';
-		if (rc != 0 && !ft_strncmp(c, CTRL_D, 2) && i == 0)
-			get_eof(line, hist);
-		else if (rc != 0 && !ft_strncmp(c, CTRL_D, 2))
-			write(1, "\007", 1);
-		else if (rc != 0 && !ft_strncmp(c, CTRL_C, 2))
-			line = get_sigint(line, c);
-		else if (!ft_strncmp(c, UPKEY, 4) || !ft_strncmp(c, DOWNKEY, 4))
-			line = display_history(line, c, &i, hist);
-		else if (rc != 0)
+		if (rc != 0 && !check_control(c, &i, line, hist))
 			line = check_input(line, c, &i, rc);
 	}
 	return (line);
@@ -76,7 +85,7 @@ static char	*get_line(char *line, t_hist **hist)
 
 char	*read_line(t_hist **hist)
 {
-	extern t_termcap	term;
+	//extern t_termcap	term;
 	char				*line;
 	char				*tmp;
 
@@ -88,7 +97,7 @@ char	*read_line(t_hist **hist)
 	}
 	line[0] = '\0';
 	tmp = line;
-	get_cursor_position(&term.pos[0], &term.pos[1]);
+	//get_cursor_position(&term.pos[0], &term.pos[1]);
 	line = get_line(line, hist);
 	if (!reset_terminal_setting() || !line)
 	{

--- a/srcs/main/read_line.c
+++ b/srcs/main/read_line.c
@@ -28,6 +28,8 @@ static char	*check_input(char *line, char *c, int *i)
 	n = 0;
 	while (c[n] != '\0' && c[n] != '\n' && c[n] != '\034')
 	{
+		if (*i == BUFFER_SIZE)
+			break ;
 		ft_putchar_fd(c[n], STDOUT_FILENO);
 		move_nextline(i);
 		line[*i] = c[n];
@@ -86,11 +88,11 @@ static char	*get_line(char *line, t_hist **hist)
 
 char	*read_line(t_hist **hist)
 {
-	extern t_termcap	term;
+	//extern t_termcap	term;
 	char				*line;
 	char				*tmp;
 
-	line = malloc(sizeof(char) * BUFFER_SIZE);
+	line = malloc(sizeof(char) * (BUFFER_SIZE + 1));
 	if (!line || !set_terminal_setting())
 	{
 		free(line);
@@ -98,7 +100,7 @@ char	*read_line(t_hist **hist)
 	}
 	line[0] = '\0';
 	tmp = line;
-	get_cursor_position(&term.pos[0], &term.pos[1]);
+	//get_cursor_position(&term.pos[0], &term.pos[1]);
 	line = get_line(line, hist);
 	if (!reset_terminal_setting() || !line)
 	{

--- a/srcs/main/read_line.c
+++ b/srcs/main/read_line.c
@@ -5,6 +5,7 @@
 #define RIGHTKEY	"\033[C"
 #define LEFTKEY		"\033[D"
 #define BACKSPACE	"\177"
+#define TAB			"\t"
 #define CTRL_D		"\004"
 #define CTRL_C		"\003"
 
@@ -42,13 +43,13 @@ static char	*check_input(char *line, char *c, int *i)
 
 static bool	check_control(char *c, int *i, char *line, t_hist **hist)
 {
-	if (!ft_strncmp(c, BACKSPACE, 2)
+	if (!ft_strncmp(c, BACKSPACE, 2) || !ft_strncmp(c, TAB, 2)
 		|| !ft_strncmp(c, CTRL_D, 2) || !ft_strncmp(c, CTRL_C, 2)
 		|| !ft_strncmp(c, UPKEY, 4) || !ft_strncmp(c, DOWNKEY, 4))
 	{
 		if (!ft_strncmp(c, CTRL_D, 2) && *i == 0)
 			get_eof(line, hist);
-		else if (!ft_strncmp(c, CTRL_D, 2))
+		else if (!ft_strncmp(c, CTRL_D, 2) || !ft_strncmp(c, TAB, 2))
 			write(1, "\007", 1);
 		else if (!ft_strncmp(c, BACKSPACE, 2))
 			back_line(line, i);

--- a/srcs/main/read_line.c
+++ b/srcs/main/read_line.c
@@ -88,7 +88,7 @@ static char	*get_line(char *line, t_hist **hist)
 
 char	*read_line(t_hist **hist)
 {
-	//extern t_termcap	term;
+	extern t_termcap	term;
 	char				*line;
 	char				*tmp;
 
@@ -100,7 +100,7 @@ char	*read_line(t_hist **hist)
 	}
 	line[0] = '\0';
 	tmp = line;
-	//get_cursor_position(&term.pos[0], &term.pos[1]);
+	get_cursor_position(&term.pos[0], &term.pos[1]);
 	line = get_line(line, hist);
 	if (!reset_terminal_setting() || !line)
 	{

--- a/srcs/main/read_line.c
+++ b/srcs/main/read_line.c
@@ -21,19 +21,20 @@ void	move_nextline(int *len)
 	}
 }
 
-static char	*check_input(char *line, char *c, int *i, int rc)
+static char	*check_input(char *line, char *c, int *i)
 {
-	if (!ft_strncmp(c, "\v", 2) || !ft_strncmp(c, "\r", 2)
-		|| !ft_strncmp(c, "\f", 2) || !ft_strncmp(c, "\t", 2))
-		write(STDOUT_FILENO, "\007", 1);
-	else if (rc == 1 && c[0] != '\n' && c[0] != '\034')
+	int	n;
+
+	n = 0;
+	while (c[n] != '\0' && c[n] != '\n' && c[n] != '\034')
 	{
-		ft_putchar_fd(c[0], STDOUT_FILENO);
+		ft_putchar_fd(c[n], STDOUT_FILENO);
 		move_nextline(i);
-		line[*i] = c[0];
+		line[*i] = c[n];
 		(*i)++;
-		line[*i] = '\0';
+		n++;
 	}
+	line[*i] = '\0';
 	return (line);
 }
 
@@ -65,7 +66,7 @@ static bool	check_control(char *c, int *i, char *line, t_hist **hist)
 
 static char	*get_line(char *line, t_hist **hist)
 {
-	char	c[8];
+	char	c[64];
 	int		i;
 	int		rc;
 
@@ -73,19 +74,19 @@ static char	*get_line(char *line, t_hist **hist)
 	c[0] = '\0';
 	while (c[0] != '\n')
 	{
-		rc = read(STDIN_FILENO, c, 7);
+		rc = read(STDIN_FILENO, c, 63);
 		if (rc == -1)
 			return (NULL);
 		c[rc] = '\0';
 		if (rc != 0 && !check_control(c, &i, line, hist))
-			line = check_input(line, c, &i, rc);
+			line = check_input(line, c, &i);
 	}
 	return (line);
 }
 
 char	*read_line(t_hist **hist)
 {
-	//extern t_termcap	term;
+	extern t_termcap	term;
 	char				*line;
 	char				*tmp;
 
@@ -97,7 +98,7 @@ char	*read_line(t_hist **hist)
 	}
 	line[0] = '\0';
 	tmp = line;
-	//get_cursor_position(&term.pos[0], &term.pos[1]);
+	get_cursor_position(&term.pos[0], &term.pos[1]);
 	line = get_line(line, hist);
 	if (!reset_terminal_setting() || !line)
 	{


### PR DESCRIPTION
コピペ等で一度に複数文字入力されたときの動作を改善しました。
また、散らばっていた制御系文字を受け取った際の動作を一つの関数にまとめました。
validate_line修正時にheaderに宣言して名前が重複していた他のstatic関数の関数名を変更しました。