### PR TITLE
exitの引数に標準空白文字類がある場合の対応

### DIFF
--- a/srcs/builtin/execute_exit.c
+++ b/srcs/builtin/execute_exit.c
@@ -73,12 +73,12 @@ int	execute_exit(t_command *cmd)
 		ft_putendl_fd("exit", STDERR_FILENO);
 		wrap_exit(EXIT_SUCCESS);
 	}
-	if (!is_digits(str))
+	if (!is_digits(str) && *str != ' ')
 		wrap_exit(print_error(str, ": numeric argument required\n"));
 	if (cmd->argv[(!ft_strncmp(cmd->argv[1], "--", 3)) + 2] != NULL)
 	{
 		exit_status = print_error("too many arguments\n", NULL);
-		if (is_digits(str))
+		if (is_digits(str) && *str != ' ')
 			wrap_exit(EXIT_FAILURE);
 		wrap_exit(exit_status);
 	}

--- a/srcs/builtin/execute_exit.c
+++ b/srcs/builtin/execute_exit.c
@@ -85,7 +85,7 @@ int	execute_exit(t_command *cmd)
 	if (cmd->argv[(!ft_strncmp(cmd->argv[1], "--", 3)) + 2] != NULL)
 	{
 		exit_status = print_error("too many arguments\n", NULL);
-		if (!is_validstr(str))
+		if (is_validstr(str))
 			wrap_exit(EXIT_FAILURE);
 		wrap_exit(exit_status);
 	}

--- a/srcs/builtin/execute_exit.c
+++ b/srcs/builtin/execute_exit.c
@@ -1,5 +1,7 @@
 #include "minishell.h"
 
+#define SPACES	"\v\r\f\t\n "
+
 static int	print_error(char *first, char *second)
 {
 	ft_putendl_fd("exit", STDERR_FILENO);
@@ -10,7 +12,7 @@ static int	print_error(char *first, char *second)
 	return (255);
 }
 
-static bool	is_digits(char *str)
+static bool	is_validstr(char *str)
 {
 	size_t	i;
 
@@ -20,8 +22,11 @@ static bool	is_digits(char *str)
 	if (!str[i])
 		return (false);
 	while (str[i])
-		if (!ft_isdigit(str[i++]))
+	{
+		if (!ft_isdigit(str[i]) && !ft_strchr(SPACES, str[i]))
 			return (false);
+		i++;
+	}
 	return (true);
 }
 
@@ -73,12 +78,12 @@ int	execute_exit(t_command *cmd)
 		ft_putendl_fd("exit", STDERR_FILENO);
 		wrap_exit(EXIT_SUCCESS);
 	}
-	if (!is_digits(str) && *str != ' ')
+	if (!is_validstr(str))
 		wrap_exit(print_error(str, ": numeric argument required\n"));
 	if (cmd->argv[(!ft_strncmp(cmd->argv[1], "--", 3)) + 2] != NULL)
 	{
 		exit_status = print_error("too many arguments\n", NULL);
-		if (is_digits(str) && *str != ' ')
+		if (!is_validstr(str))
 			wrap_exit(EXIT_FAILURE);
 		wrap_exit(exit_status);
 	}

--- a/srcs/builtin/execute_exit.c
+++ b/srcs/builtin/execute_exit.c
@@ -1,7 +1,5 @@
 #include "minishell.h"
 
-#define SPACES	"\v\r\f\t\n "
-
 static int	print_error(char *first, char *second)
 {
 	ft_putendl_fd("exit", STDERR_FILENO);
@@ -17,27 +15,21 @@ static bool	is_validstr(char *str)
 	size_t	i;
 
 	i = 0;
-	while (!ft_strchr(SPACES, str[i]))
+	while (ft_isspace(str[i]))
 		i++;
-	if (*str == '-' || *str == '+')
+	if (str[i] == '-' || str[i] == '+')
 		i++;
-	if (!str[i])
+	if (str[i] == '\0')
 		return (false);
-	while (str[i])
-	{
-		if (!ft_isdigit(str[i]))
-			return (false);
+	while (ft_isdigit(str[i]))
 		i++;
-	}
-	if (!str[i])
+	if (str[i] == '\0')
 		return (true);
-	while (str[i])
-	{
-		if (!ft_strchr(SPACES, str[i]))
-			return (false);
+	while (ft_isspace(str[i]))
 		i++;
-	}
-	return (true);
+	if (str[i] == '\0')
+		return (true);
+	return (false);
 }
 
 static bool	is_overflow(long long num, int bottom)

--- a/srcs/builtin/execute_exit.c
+++ b/srcs/builtin/execute_exit.c
@@ -17,13 +17,23 @@ static bool	is_validstr(char *str)
 	size_t	i;
 
 	i = 0;
+	while (!ft_strchr(SPACES, str[i]))
+		i++;
 	if (*str == '-' || *str == '+')
 		i++;
 	if (!str[i])
 		return (false);
 	while (str[i])
 	{
-		if (!ft_isdigit(str[i]) && !ft_strchr(SPACES, str[i]))
+		if (!ft_isdigit(str[i]))
+			return (false);
+		i++;
+	}
+	if (!str[i])
+		return (true);
+	while (str[i])
+	{
+		if (!ft_strchr(SPACES, str[i]))
 			return (false);
 		i++;
 	}


### PR DESCRIPTION
```
exit " 42 "
```
のようなケースを正常に見なすように修正しました。