### PR TITLE
execute_cd仕上げ

### DIFF
--- a/srcs/builtin/execute_cd.c
+++ b/srcs/builtin/execute_cd.c
@@ -1,18 +1,30 @@
 #include "minishell.h"
 
-static char	*retry_change_directory(char *path)
+#define ERR_GETCWD "cd: error retrieving current directory: getcwd:\
+ cannot access parent directories: No such file or directory"
+
+char	*retry_change_directory(char *path)
 {
 	char	*newpath;
-	char	*tmp;
+	char	*try;
 	char	*pwd;
 
 	if (chdir(path) == -1)
 		return (NULL);
 	pwd = getenv("PWD");
-	tmp = pwd;
 	if (!endswith(pwd, "/"))
-		tmp = ft_strjoin(pwd, "/");
-	newpath = ft_strjoin(tmp, path);
+		pwd = ft_strjoin(pwd, "/");
+	else
+		pwd = ft_strdup(pwd);
+	try = ft_strjoin(pwd, path);
+	free(pwd);
+	newpath = create_newpath(try);
+	if (!newpath && store_exitstatus(LOAD, errno) == ENOENT)
+	{
+		ft_putendl_fd(ERR_GETCWD, STDERR_FILENO);
+		return (try);
+	}
+	free(try);
 	return (newpath);
 }
 

--- a/srcs/builtin/execute_cd.c
+++ b/srcs/builtin/execute_cd.c
@@ -60,7 +60,7 @@ static bool	set_cdpath_iterate(char *path)
 	char	**split_path;
 	size_t	i;
 
-	if (ft_strchr(path, '.') || ft_strchr(path, '/'))
+	if (path[0] == '\0' || ft_strchr(path, '.') || ft_strchr(path, '/'))
 		return (false);
 	split_path = ft_split(getenv("CDPATH"), ':');
 	i = 0;

--- a/srcs/builtin/execute_pwd.c
+++ b/srcs/builtin/execute_pwd.c
@@ -14,6 +14,6 @@ int	execute_pwd(t_command *cmd)
 	path = getenv("PWD");
 	if (path == NULL)
 		return (EXIT_FAILURE);
-	printf("%s\n", path);
+	ft_putendl_fd(path, STDOUT_FILENO);
 	return (EXIT_SUCCESS);
 }

--- a/srcs/execute/create_newpath.c
+++ b/srcs/execute/create_newpath.c
@@ -7,12 +7,7 @@ static char	*get_cwd_with_slash(void)
 
 	path = getcwd(NULL, 0);
 	if (!path)
-	{
-		if (errno == ENOENT)
-			ft_putendl_fd("cd: error retrieving current directory: getcwd:\
- cannot access parent directories: No such file or directory", STDERR_FILENO);
 		return (NULL);
-	}
 	tmp = path;
 	path = ft_strjoin(path, "/");
 	if (!path)
@@ -80,6 +75,8 @@ char	*create_newpath(char *path)
 	t_list	*head;
 	t_list	*list;
 
+	if (!path)
+		return (NULL);
 	if (!ft_strncmp(path, "/", 2) || !ft_strncmp(path, "//", 3))
 		return (ft_strdup(path));
 	dir = get_dir_separeted_by_slash(path);

--- a/srcs/parser/parser_utils.c
+++ b/srcs/parser/parser_utils.c
@@ -53,6 +53,8 @@ bool	endswith(char *str, char *end)
 {
 	char	elen;
 
+	if (!str || !end)
+		return (false);
 	elen = ft_strlen(end);
 	return (!ft_strncmp(str + (ft_strlen(str) - elen), end, elen + 1));
 }


### PR DESCRIPTION
・カレントディレクトリを削除後、cd ../など存在するディレクトリに移動した場合の対応
・set_pathで選択したpathが空文字の時、cdpathを失敗させるように修正
・pwdのパス出力にprintfを使用しないように変更

具体的に
```
mkdir dir; cd dir; rmdir ../dir; cd ./; pwd;cd .; pwd; cd ./././././; pwd; cd .////////./; pwd; cd ../; pwd

export CDPATH="/"; export HOME=; cd ; pwd

export CDPATH="../a"; mkdir -p a/b/c; cd b; pwd; cd a; pwd; cd b; pwd
```
のような対応しきれていなかったパターンに対応しました。