### PR TITLE
[fix] export 文字列連結対応。update_shlvl修正

### DIFF
--- a/srcs/builtin/execute_export.c
+++ b/srcs/builtin/execute_export.c
@@ -17,13 +17,18 @@ static int	print_error(char *message)
 static bool	set_keyvalue(char *str, char **key, char **value)
 {
 	char	*equal;
+	char	*plus;
 
 	equal = ft_strchr(str, '=');
 	*value = NULL;
 	if (equal)
 	{
-		*key = ft_substr(str, 0, equal - str);
-		*value = ft_strdup(equal + 1);
+		plus = ft_strchr(str, '+');
+		*key = ft_substr(str, 0, equal - (str + !!plus));
+		if (plus + 1 == equal && getenv(*key))
+			*value = ft_strjoin(getenv(*key), equal + 1);
+		else
+			*value = ft_strdup(equal + 1);
 	}
 	else
 		*key = ft_strdup(str);

--- a/srcs/main/main.c
+++ b/srcs/main/main.c
@@ -83,6 +83,7 @@ int	main(int argc, char **argv)
 	hist = NULL;
 	create_newenv();
 	init_tterm();
+	update_env("OLDPWD", NULL);
 	if (!update_shlvl())
 		wrap_exit(EXIT_FAILURE);
 	if (argc > 2 && !ft_strncmp(argv[1], "-c", 3))

--- a/srcs/utils/print_sorted_env.c
+++ b/srcs/utils/print_sorted_env.c
@@ -40,12 +40,9 @@ static void	merge(char **a, char **b, size_t index[3])
 	else
 		while (i < index[MID])
 			b[k++] = a[i++];
-	i = 0;
-	while (i < k)
-	{
+	i = k;
+	while (i--)
 		a[index[FRONT] + i] = b[i];
-		i++;
-	}
 }
 
 void	sort_environ(char **a, char **b, size_t front, size_t end)

--- a/srcs/utils/print_sorted_env.c
+++ b/srcs/utils/print_sorted_env.c
@@ -4,21 +4,18 @@
 #define MID 1
 #define END 2
 
-static char	*get_str_literal(char *str)
+static bool	get_str_literal(char *str, char **literal)
 {
 	char	*ptr;
-	char	*literal;
 
+	*literal = NULL;
 	ptr = ft_strchr(str, '=');
-	if (ptr)
-	{
-		ptr = ft_strdup(ptr + 1);
-		literal = ft_str_sandwich(ptr, "\"");
-		free(ptr);
-	}
-	else
-		literal = ft_strdup(str);
-	return (literal);
+	if (!ptr)
+		return (false);
+	ptr = ft_strdup(ptr);
+	*literal = ft_str_sandwich(ptr, "\"");
+	free(ptr);
+	return (true);
 }
 
 static void	merge(char **a, char **b, size_t index[3])
@@ -40,7 +37,7 @@ static void	merge(char **a, char **b, size_t index[3])
 	if (i == index[MID])
 		while (j < index[END])
 			b[k++] = a[j++];
-	if (i != index[MID])
+	else
 		while (i < index[MID])
 			b[k++] = a[i++];
 	i = 0;
@@ -85,7 +82,7 @@ char	**get_sorted_environ(void)
 		free(buf);
 		return (NULL);
 	}
-	ft_memcpy(sorted, environ, sizeof(char *) * i);
+	ft_memcpy(sorted, environ, sizeof(char *) * (i + 1));
 	sorted[i] = NULL;
 	sort_environ(sorted, buf, 0, i);
 	free(buf);
@@ -96,6 +93,7 @@ int	print_sorted_env(void)
 {
 	char	**sorted;
 	char	*value;
+	bool	has_value;
 	size_t	i;
 
 	sorted = get_sorted_environ();
@@ -104,15 +102,16 @@ int	print_sorted_env(void)
 	i = 0;
 	while (sorted[i] != NULL)
 	{
-		value = get_str_literal(sorted[i]);
-		if (!value)
+		has_value = get_str_literal(sorted[i], &value);
+		if (has_value && !value)
 			return (EXIT_FAILURE);
-		printf("declare -x ");
-		while (*sorted[i] != '=')
-			putchar(*sorted[i]++);
-		putchar(*sorted[i]++);
-		printf("%s\n", value);
+		ft_putstr_fd("declare -x ", STDOUT_FILENO);
+		while (*sorted[i] && *sorted[i] != '=')
+			ft_putchar(*sorted[i]++);
+		if (has_value)
+			ft_putstr_fd(value, STDOUT_FILENO);
 		free(value);
+		ft_putendl_fd("", STDOUT_FILENO);
 		i++;
 	}
 	free(sorted);

--- a/srcs/utils/print_sorted_env.c
+++ b/srcs/utils/print_sorted_env.c
@@ -12,8 +12,8 @@ static bool	get_str_literal(char *str, char **literal)
 	ptr = ft_strchr(str, '=');
 	if (!ptr)
 		return (false);
-	ptr = ft_strdup(ptr);
-	*literal = ft_str_sandwich(ptr, "\"");
+	ptr = ft_str_sandwich(ptr + 1, "\"");
+	*literal = ft_strjoin("=", ptr);
 	free(ptr);
 	return (true);
 }
@@ -29,7 +29,7 @@ static void	merge(char **a, char **b, size_t index[3])
 	k = 0;
 	while (i < index[MID] && j < index[END])
 	{
-		if (ft_strncmp(a[i], a[j], ft_strlen(a[i])) < 0)
+		if (ft_strncmp(a[i], a[j], INT_MAX) < 0)
 			b[k++] = a[i++];
 		else
 			b[k++] = a[j++];

--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -1,5 +1,7 @@
 #include "minishell.h"
 
+#define SPACES	"\v\r\f\t\n "
+
 static void	output_error(char *val)
 {
 	ft_putstr_fd("minishell: warning: shell level (", STDERR_FILENO);
@@ -28,7 +30,7 @@ bool	update_shlvl(void)
 	int			value;
 	bool		ret;
 
-	env = getenv("SHLVL");
+	env = ft_strtrim( getenv("SHLVL"), SPACES);
 	if (env == NULL)
 		return (add_newval_to_env("SHLVL=1"));
 	if (!is_valid_shlvl(env))


### PR DESCRIPTION
```
export APPEND=1; export APPEND+=2; export | grep APPEND
export APPEND_NONE=1; export APPEND_NONE+=; export | grep APPEND_NONE
```

以上のような環境変数のvalueに文字列連結するパターンに対応しました。
update_shlvl内でgetenvしてくるSHLVL環境変数のvalueに含まれる標準空白文字類を取り除くようにしました。