### PR TITLE
[fix]execute_cdメモリリーク修正

### DIFF
--- a/srcs/builtin/execute_cd.c
+++ b/srcs/builtin/execute_cd.c
@@ -115,7 +115,10 @@ int	execute_cd(t_command *cmd)
 	if (!path)
 		return (EXIT_FAILURE);
 	if (set_cdpath_iterate(path))
+	{
+		free(path);
 		return (EXIT_SUCCESS);
+	}
 	status = change_directory(path, false);
 	if (status)
 	{

--- a/srcs/execute/create_newpath.c
+++ b/srcs/execute/create_newpath.c
@@ -36,7 +36,10 @@ static char	**get_dir_separeted_by_slash(char *path)
 	if (!newpath)
 		return (NULL);
 	if (stat(newpath, &sb) == -1)
+	{
+		free(newpath);
 		return (NULL);
+	}
 	dir = ft_split(newpath, '/');
 	free(newpath);
 	return (dir);
@@ -62,7 +65,7 @@ static t_list	*create_hierarchy(char **dir)
 			}
 		}
 		else if (ft_strncmp(*dir, ".", 2))
-			ft_lstadd_back(&list, ft_lstnew(*dir));
+			ft_lstadd_back(&list, ft_lstnew(ft_strdup(*dir)));
 		dir++;
 	}
 	return (list);
@@ -90,5 +93,6 @@ char	*create_newpath(char *path)
 		list = list->next;
 	newpath = add_path_iterate(list);
 	ft_lstclear(&head, free);
+	ft_free_split(dir);
 	return (newpath);
 }

--- a/srcs/execute/create_newpath.c
+++ b/srcs/execute/create_newpath.c
@@ -45,27 +45,37 @@ static char	**get_dir_separeted_by_slash(char *path)
 	return (dir);
 }
 
-static t_list	*create_hierarchy(char **dir)
+static void	lstdelone_beforenull(t_list **list)
 {
 	t_list	*last;
+
+	last = *list;
+	if (last)
+	{
+		while (last->next && last->next->next)
+			last = last->next;
+		ft_lstdelone(last->next, free);
+		last->next = NULL;
+	}
+}
+
+static t_list	*create_hierarchy(char **dir)
+{
 	t_list	*list;
+	char	*content;
 
 	list = ft_lstnew(NULL);
 	while (dir && *dir != NULL)
 	{
 		if (!ft_strncmp(*dir, "..", 3))
-		{
-			last = list;
-			if (last)
-			{
-				while (last->next && last->next->next)
-					last = last->next;
-				ft_lstdelone(last->next, free);
-				last->next = NULL;
-			}
-		}
+			lstdelone_beforenull(&list);
 		else if (ft_strncmp(*dir, ".", 2))
-			ft_lstadd_back(&list, ft_lstnew(ft_strdup(*dir)));
+		{
+			content = ft_strdup(*dir);
+			if (!content)
+				break ;
+			ft_lstadd_back(&list, ft_lstnew(content));
+		}
 		dir++;
 	}
 	return (list);

--- a/srcs/execute/create_newpath.c
+++ b/srcs/execute/create_newpath.c
@@ -73,7 +73,10 @@ static t_list	*create_hierarchy(char **dir)
 		{
 			content = ft_strdup(*dir);
 			if (!content)
-				break ;
+			{
+				ft_lstclear(&list, free);
+				return (NULL);
+			}
 			ft_lstadd_back(&list, ft_lstnew(content));
 		}
 		dir++;

--- a/srcs/utils/add_path.c
+++ b/srcs/utils/add_path.c
@@ -50,5 +50,6 @@ char	*add_path(char *path, char *dir)
 	oldpath = newpath;
 	newpath = ft_strjoin(oldpath, dir);
 	free(oldpath);
+	free(path);
 	return (newpath);
 }

--- a/tests/execute/test_create_newpath.c
+++ b/tests/execute/test_create_newpath.c
@@ -10,5 +10,6 @@ int		main(int argc, char **argv)
 		return (1);
 	path = create_newpath(argv[1]);
 	puts(path);
+	free(path);
 	return (0);
 }


### PR DESCRIPTION
add_path_iterate(), set_cdpath_iterate()内からコールされるadd_pathで引数として受け取った変数pathをfreeするよう変更しました。
また、create_hierarchy()内で生成されるlistは引数dirを完全に包括しないのでlistのcontentはdupしたものを渡し、create_newpath()内でdirをフリーするように変更しました。
確認お願いします。