### PR TITLE
[fix] do_redirection.c, error_redirect.c修正

### DIFF
--- a/srcs/execute/do_redirection.c
+++ b/srcs/execute/do_redirection.c
@@ -29,7 +29,7 @@ static int	is_appending(char *arg)
 	i = ft_strlen(arg);
 	if (arg[i - 1] == '>' && arg[i - 2] == '>')
 		return (O_RDWR | O_CREAT | O_APPEND);
-	return (O_WRONLY | O_CREAT);
+	return (O_WRONLY | O_CREAT | O_TRUNC);
 }
 
 /*

--- a/srcs/execute/error_redirect.c
+++ b/srcs/execute/error_redirect.c
@@ -15,7 +15,7 @@ bool	redirect_error(char *key, char *errmsg)
 bool	fd_error(long fd, char *errmsg)
 {
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
-	if (fd < INT_MAX)
+	if (fd <= INT_MAX)
 		ft_putnbr_fd((int)fd, STDERR_FILENO);
 	else
 		ft_putstr_fd("file descriptor out of range", STDERR_FILENO);


### PR DESCRIPTION
・> のようなリダイレクトの場合に、ファイルの中身を上書きするようにis_appending()のflagを修正しました。
・fdの数値が正常な範囲かの判定を fd < INT_MAXから fd <= INT_MAXに修正しました。