### PR TITLE
[fix] shlvlのvalueが正常かどうかの判定を修正

### DIFF
--- a/srcs/utils/update_shlvl.c
+++ b/srcs/utils/update_shlvl.c
@@ -42,7 +42,10 @@ bool	update_shlvl(void)
 	int		value;
 	bool	ret;
 
-	env = ft_strtrim(getenv("SHLVL"), SPACES);
+	env = getenv("SHLVL");
+	while (env && ft_strchr(SPACES, *env))
+		env++;
+	env = ft_strtrim(env, "\t\n ");
 	if (env == NULL || !is_valid_shlvl(env))
 		return (reset_shlvl("1", env));
 	value = ft_atoi(env);


### PR DESCRIPTION
```
SPACES = "\v\r\f\t\n "
TRIMS = "\t\n "
VALUE = [SPACES]* [DIGITS] [TRIMS]*
```

valueが正常かどうかの判定を、以前はft_strtrimで標準空白文字類を取り除いてから行っていました。
今回の修正では、上のVALUEのパターンに当てはまるものを正常としました。
前にあるSPACESを飛ばし、ft_strtrimでTRIMSを除いたもの(DIGITS)が変数envに渡されます。