### PR TITLE
[fix] クオートが閉じていない時のエラーメッセージ変更。validate_quoteとlineの実行順変更。

### DIFF
--- a/srcs/main/main.c
+++ b/srcs/main/main.c
@@ -19,7 +19,7 @@ static char	*check_validline(char *line)
 	tmp = ft_strtrim(line, SPACES);
 	if (tmp == NULL)
 		return (NULL);
-	if (!validate_line(tmp) || !validate_quote(tmp))
+	if (!validate_quote(tmp) || !validate_line(tmp))
 	{
 		free(tmp);
 		free(line);

--- a/srcs/tokenizer/validate_quote.c
+++ b/srcs/tokenizer/validate_quote.c
@@ -4,6 +4,14 @@
 ** lineのクォートが閉じているかの判定
 */
 
+static void	print_error(char quote)
+{
+	ft_putstr_fd("minishell: unexpected EOF while looking for matching `", \
+	STDERR_FILENO);
+	ft_putchar_fd(quote, STDERR_FILENO);
+	ft_putendl_fd("'", STDERR_FILENO);
+}
+
 bool	validate_quote(char *line)
 {
 	char	quote;
@@ -22,7 +30,7 @@ bool	validate_quote(char *line)
 			}
 			if (*line == '\0')
 			{
-				ft_putendl_fd("minishell: Quote is not closed.", 2);
+				print_error(quote);
 				return (false);
 			}
 		}


### PR DESCRIPTION
```
echo '
echo "
```
以上のようなパターンでセグフォが出ていたので、validate_quoteをvalidate_lineの前に呼び出すようにして解決しました。
また、クオートが閉じていない時のエラーメッセージをbashに合わせました。