### PR TITLE
Feature/fix receive pipe

### DIFF
--- a/srcs/execute/connect_pipeline.c
+++ b/srcs/execute/connect_pipeline.c
@@ -23,7 +23,8 @@ static bool	send_pipeline(t_command *cmd, int newpipe[2])
 
 static bool	receive_pipeline(t_command *cmd)
 {
-	if (cmd->receive_pipe == false)
+	if (cmd->receive_pipe == false
+		|| (cmd->lastfd[0] == -1 && cmd->lastfd[1] == -1))
 		return (true);
 	if (close(cmd->lastfd[1]) == -1)
 		return (error_piping("close: "));

--- a/srcs/execute/start_commands.c
+++ b/srcs/execute/start_commands.c
@@ -1,6 +1,5 @@
 #include "minishell.h"
 
-
 static void	print_signal_message(t_command *cmd, int status)
 {
 	if (WIFSIGNALED(status) && WTERMSIG(status) == 3 && cmd->next == NULL)
@@ -12,7 +11,7 @@ static void	print_signal_message(t_command *cmd, int status)
 	}
 }
 
-static void	confirm_child(t_command *cmd_ptr, t_command *cmd)
+static t_command	*confirm_child(t_command *cmd_ptr, t_command *cmd)
 {
 	int			status;
 	t_command	*end;
@@ -35,6 +34,7 @@ static void	confirm_child(t_command *cmd_ptr, t_command *cmd)
 			store_exitstatus(SAVE, cmd_ptr->exitstatus);
 		cmd_ptr = cmd_ptr->next;
 	}
+	return (end);
 }
 
 void	start_commands(t_command *cmd)
@@ -60,10 +60,7 @@ void	start_commands(t_command *cmd)
 			reconnect_stdfd(LOAD);
 		}
 		if (cmd->op == SCOLON || cmd->op == EOS)
-		{
-			confirm_child(cmd_ptr, cmd);
-			cmd_ptr = cmd->next;
-		}
+			cmd_ptr = confirm_child(cmd_ptr, cmd);
 		cmd = cmd->next;
 	}
 	free_commandslist(&cmd);

--- a/srcs/execute/start_commands.c
+++ b/srcs/execute/start_commands.c
@@ -46,7 +46,10 @@ void	start_commands(t_command *cmd)
 	while (cmd != NULL)
 	{
 		if (!validate_redirect(cmd))
-			return ;
+		{
+			cmd = cmd->next;
+			continue ;
+		}
 		if (!preprocess_command(cmd))
 			return ;
 		if (cmd->op == PIPELINE || cmd->receive_pipe == true)


### PR DESCRIPTION
```echo a > $NO_ENV | echo b```
のようなコマンドでリダイレクトのエラーが発生したときその時点でコマンド実行を終了せずに、すべてのコマンドを実行するよう変更しました。
また、エラーでコマンドが実行されなかったときパイプを受け取るコマンドでエラーが発生しないようlastfdが初期値の時receive_pipeline()を実行しないよう変更しました。