### PR TITLE
[fix] export 特殊文字のエスケープを文字列表示時のみにするよう修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SRCFILE =	srcs/main/main.c \
 			srcs/utils/validate_envkey.c \
 			srcs/utils/update_env.c \
 			srcs/utils/print_sorted_env.c \
+			srcs/utils/sort_environ.c \
 			srcs/utils/wrap_exit.c \
 			srcs/utils/get_escapestr.c \
 			srcs/utils/add_path.c \

--- a/srcs/builtin/execute_export.c
+++ b/srcs/builtin/execute_export.c
@@ -14,34 +14,6 @@ static int	print_error(char *message)
 	return (EXIT_FAILURE);
 }
 
-static char	*set_value(char *line)
-{
-	char	*tmp;
-	char	*str;
-	int		i;
-
-	tmp = malloc(ft_strlen(line) * 2 + 1);
-	if (tmp == NULL)
-		return (NULL);
-	i = 0;
-	while (*line)
-	{
-		if (ft_strchr("\"$\'\\", *line))
-		{
-			tmp[i++] = '\\';
-			tmp[i++] = *line++;
-			if (line && ft_strchr("\"$\'", *line))
-				tmp[i++] = *line++;
-		}
-		else
-			tmp[i++] = *line++;
-	}
-	tmp[i] = '\0';
-	str = ft_strdup(tmp);
-	free(tmp);
-	return (str);
-}
-
 static bool	set_keyvalue(char *str, char **key, char **value)
 {
 	char	*equal;
@@ -56,7 +28,7 @@ static bool	set_keyvalue(char *str, char **key, char **value)
 		if (plus + 1 == equal && getenv(*key))
 			*value = ft_strjoin(getenv(*key), equal + 1);
 		else
-			*value = set_value(equal + 1);
+			*value = ft_strdup(equal + 1);
 	}
 	else
 		*key = ft_strdup(str);

--- a/srcs/utils/print_sorted_env.c
+++ b/srcs/utils/print_sorted_env.c
@@ -1,64 +1,45 @@
 #include "minishell.h"
 
-#define FRONT 0
-#define MID 1
-#define END 2
+static char	*create_escaped_str(char *str)
+{
+	char	*tmp;
+	char	*esc;
+	int		i;
+
+	tmp = malloc(ft_strlen(str) * 2 + 1);
+	if (tmp == NULL)
+		return (NULL);
+	i = 0;
+	while (*str)
+	{
+		if (ft_strchr("\"$\'\\", *str))
+		{
+			tmp[i++] = '\\';
+			tmp[i++] = *str++;
+			if (str && ft_strchr("\"$\'", *str))
+				tmp[i++] = *str++;
+		}
+		else
+			tmp[i++] = *str++;
+	}
+	tmp[i] = '\0';
+	esc = ft_strdup(tmp);
+	free(tmp);
+	return (esc);
+}
 
 static bool	get_str_literal(char *str, char **literal)
 {
-	char	*ptr;
+	char	*equal;
 
 	*literal = NULL;
-	ptr = ft_strchr(str, '=');
-	if (!ptr)
+	equal = ft_strchr(str, '=');
+	if (!equal)
 		return (false);
-	ptr = ft_str_sandwich(ptr + 1, "\"");
-	*literal = ft_strjoin("=", ptr);
-	free(ptr);
+	*literal = create_escaped_str(equal + 1);
+	*literal = ft_str_sandwich(*literal, "\"");
+	*literal = ft_strjoin("=", *literal);
 	return (true);
-}
-
-static void	merge(char **a, char **b, size_t index[3])
-{
-	size_t	i;
-	size_t	j;
-	size_t	k;
-
-	i = index[FRONT];
-	j = index[MID];
-	k = 0;
-	while (i < index[MID] && j < index[END])
-	{
-		if (ft_strncmp(a[i], a[j], INT_MAX) < 0)
-			b[k++] = a[i++];
-		else
-			b[k++] = a[j++];
-	}
-	if (i == index[MID])
-		while (j < index[END])
-			b[k++] = a[j++];
-	else
-		while (i < index[MID])
-			b[k++] = a[i++];
-	i = k;
-	while (i--)
-		a[index[FRONT] + i] = b[i];
-}
-
-void	sort_environ(char **a, char **b, size_t front, size_t end)
-{
-	size_t	mid;
-	size_t	index[3];
-
-	if (front == end || front + 1 == end)
-		return ;
-	mid = (front + end) / 2;
-	sort_environ(a, b, front, mid);
-	sort_environ(a, b, mid, end);
-	index[0] = front;
-	index[1] = mid;
-	index[2] = end;
-	merge(a, b, index);
 }
 
 char	**get_sorted_environ(void)

--- a/srcs/utils/sort_environ.c
+++ b/srcs/utils/sort_environ.c
@@ -1,0 +1,48 @@
+#include "minishell.h"
+
+#define FRONT	0
+#define MID		1
+#define END		2
+
+static void	merge(char **a, char **b, size_t index[3])
+{
+	size_t	i;
+	size_t	j;
+	size_t	k;
+
+	i = index[FRONT];
+	j = index[MID];
+	k = 0;
+	while (i < index[MID] && j < index[END])
+	{
+		if (ft_strncmp(a[i], a[j], INT_MAX) < 0)
+			b[k++] = a[i++];
+		else
+			b[k++] = a[j++];
+	}
+	if (i == index[MID])
+		while (j < index[END])
+			b[k++] = a[j++];
+	else
+		while (i < index[MID])
+			b[k++] = a[i++];
+	i = k;
+	while (i--)
+		a[index[FRONT] + i] = b[i];
+}
+
+void	sort_environ(char **a, char **b, size_t front, size_t end)
+{
+	size_t	mid;
+	size_t	index[3];
+
+	if (front == end || front + 1 == end)
+		return ;
+	mid = (front + end) / 2;
+	sort_environ(a, b, front, mid);
+	sort_environ(a, b, mid, end);
+	index[0] = front;
+	index[1] = mid;
+	index[2] = end;
+	merge(a, b, index);
+}


### PR DESCRIPTION
exportの修正を忘れてしまっていて、遅くなりました。
上の修正の為、print_sorted_env.cの一部関数を、新ファイルsort_environ.cに分けました。