### PR TITLE
[fix]validate_line,tokenizer修正

### DIFF
--- a/srcs/tokenizer/tokenize.c
+++ b/srcs/tokenizer/tokenize.c
@@ -67,7 +67,7 @@ static int	get_index(char *p)
 ** <>が来たとき前のトークンが数字のみor>が連続するときの場合結合する。
 */
 
-static char	**check_lasttoken(char **tokens, char *op)
+static char	**check_lasttoken(char **tokens, char *op, char *p)
 {
 	int		i;
 	int		j;
@@ -82,8 +82,8 @@ static char	**check_lasttoken(char **tokens, char *op)
 	j = 0;
 	while (ft_isdigit(tokens[i][j]))
 		j++;
-	if (tokens[i][j] == '\0' || \
-	(ft_strchr("<>", tokens[i][j]) && tokens[i][j + 1] == '\0'))
+	if (((ft_strchr("<>", tokens[i][j]) && tokens[i][j + 1] == '\0')
+		|| tokens[i][j] == '\0') && !ft_isspace(*(p - 1)))
 	{
 		tmp = tokens[i];
 		tokens[i] = ft_strjoin(tokens[i], op);
@@ -109,7 +109,7 @@ static char	*put_op_token(char ***tokens, char *p)
 	if (!(*p == '>' || *p == '<') || *tokens == NULL)
 		*tokens = add_str_to_list(*tokens, tmp);
 	else if (*p == '>' || *p == '<')
-		*tokens = check_lasttoken(*tokens, tmp);
+		*tokens = check_lasttoken(*tokens, tmp, p);
 	free(tmp);
 	if (*tokens == NULL)
 		return (NULL);

--- a/srcs/tokenizer/tokenize.c
+++ b/srcs/tokenizer/tokenize.c
@@ -108,7 +108,7 @@ static char	*put_op_token(char ***tokens, char *p)
 		return (NULL);
 	if (!(*p == '>' || *p == '<') || *tokens == NULL)
 		*tokens = add_str_to_list(*tokens, tmp);
-	if (*p == '>' || *p == '<')
+	else if (*p == '>' || *p == '<')
 		*tokens = check_lasttoken(*tokens, tmp);
 	free(tmp);
 	if (*tokens == NULL)

--- a/srcs/tokenizer/tokenize.c
+++ b/srcs/tokenizer/tokenize.c
@@ -83,7 +83,7 @@ static char	**check_lasttoken(char **tokens, char *op, char *p)
 	while (ft_isdigit(tokens[i][j]))
 		j++;
 	if (((ft_strchr("<>", tokens[i][j]) && tokens[i][j + 1] == '\0')
-		|| tokens[i][j] == '\0') && !ft_isspace(*(p - 1)))
+			|| tokens[i][j] == '\0') && !ft_isspace(*(p - 1)))
 	{
 		tmp = tokens[i];
 		tokens[i] = ft_strjoin(tokens[i], op);

--- a/srcs/tokenizer/validate_line.c
+++ b/srcs/tokenizer/validate_line.c
@@ -46,7 +46,7 @@ static bool	check_operator(char *line, char last_op)
 			has_space = true;
 		else if (ft_strchr("<>", *line) && last_op == *line && !has_space)
 			return (check_redirect(line + 1));
-		else if (ft_strchr("<>", *line))
+		else if (ft_strchr("<>", *line) && last_op != ';' && last_op != '|')
 			return (error_return(line, last_op, has_space));
 		else if (ft_strchr(SEP, *line))
 			return (error_return(line, last_op, has_space));

--- a/tests/tokenizer/test_validate_line.c
+++ b/tests/tokenizer/test_validate_line.c
@@ -20,10 +20,16 @@ int main(void)
 {
 	bool	ret;
 
-	ret = test_line("<>", "syntax error near unexpected token `newline'");
+	ret = test_line("echo hello | >outfile grep hello", "valid");
 	output_ret(ret);
 
-	ret = test_line("<>a", "syntax error near unexpected token `newline'");
+	ret = test_line("echo hello ; >outfile ls", "valid");
+	output_ret(ret);
+
+	ret = test_line("<>", "syntax error near unexpected token `>'");
+	output_ret(ret);
+
+	ret = test_line("<>a", "syntax error near unexpected token `>'");
 	output_ret(ret);
 
 	ret = test_line("< >", "syntax error near unexpected token `>'");


### PR DESCRIPTION
```echo hello ; >outfile ls```のようなセミコロン、パイプの直後に<>があるときエラーにならないよう修正しました。
```echo hello 1 > outfile```のようなコマンドで1と>が一つのトークンとして認識されていた問題を修正しました。